### PR TITLE
feat: add new flag to generate completion script

### DIFF
--- a/cmd/chatgpt/main.go
+++ b/cmd/chatgpt/main.go
@@ -4,6 +4,11 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/kardolus/chatgpt-cli/client"
 	"github.com/kardolus/chatgpt-cli/config"
 	"github.com/kardolus/chatgpt-cli/configmanager"
@@ -11,10 +16,6 @@ import (
 	"github.com/kardolus/chatgpt-cli/http"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"strings"
-	"time"
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 	GitCommit       string
 	GitVersion      string
 	ServiceURL      string
+	shell           string
 )
 
 func main() {
@@ -54,6 +56,8 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&listThreads, "list-threads", "", false, "List available threads")
 	rootCmd.PersistentFlags().StringVar(&modelName, "set-model", "", "Set a new default GPT model by specifying the model name")
 	rootCmd.PersistentFlags().StringVar(&threadName, "set-thread", "", "Set a new active thread by specifying the thread name")
+	rootCmd.PersistentFlags().StringVar(&shell, "set-completions", "", "Generate autocompletion script for your current SHELL")
+
 	rootCmd.PersistentFlags().IntVar(&maxTokens, "set-max-tokens", 0, "Set a new default max token size by specifying the max tokens")
 
 	viper.AutomaticEnv()
@@ -69,6 +73,10 @@ func run(cmd *cobra.Command, args []string) error {
 	if showVersion {
 		fmt.Printf("ChatGPT CLI version %s (commit %s)\n", GitVersion, GitCommit)
 		return nil
+	}
+
+	if cmd.Flag("set-completions").Changed {
+		return config.GenCompletions(cmd, shell)
 	}
 
 	if cmd.Flag("set-model").Changed {
@@ -124,7 +132,7 @@ func run(cmd *cobra.Command, args []string) error {
 		if c, err := cm.ShowConfig(); err != nil {
 			return err
 		} else {
-			fmt.Printf(c)
+			fmt.Println(c)
 		}
 		return nil
 	}

--- a/config/completions.go
+++ b/config/completions.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func GenCompletions(command *cobra.Command, shell string) error {
+
+	var completionCmd = &cobra.Command{
+		Use:   "chatgpt --set-completions [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+
+Bash:
+
+  $ source <(chatgpt --set-completions bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ chatgpt --set-completions bash > /etc/bash_completion.d/chatgpt
+  # macOS:
+  $ chatgpt --set-completions bash > /usr/local/etc/bash_completion.d/chatgpt
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ chatgpt --set-completions zsh > "${fpath[1]}/_chatgpt"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ chatgpt --set-completions fish | source
+
+  # To load completions for each session, execute once:
+  $ chatgpt --set-completions fish > ~/.config/fish/completions/chatgpt.fish
+
+PowerShell:
+
+  PS> chatgpt --set-completions powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> chatgpt --set-completions powershell > chatgpt.ps1
+  # and source this file from your PowerShell profile.
+`,
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+		DisableFlagParsing:    true,
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				command.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				command.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				command.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				command.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			case "-h", "--help":
+				cmd.Help()
+			default:
+				fmt.Printf(`
+Usage:
+  chatgpt --set-completions [bash|zsh|fish|powershell]
+
+Flags:
+  -h, --help   help for --set-completions
+
+Invalid Arg: %s
+`, args[0])
+			}
+		},
+	}
+	completionCmd.SetArgs([]string{shell})
+	return completionCmd.Execute()
+}


### PR DESCRIPTION
Add a simple logic to generate a completion script.

The following is the "proof"

resolve #26 

---
##### ChatGpt prompt:
```
╰─➤ go run cmd/chatgpt/main.go hello world 👋                                                                                  
Hello! How can I assist you today?
```

---
##### Set completion flag without input:
```
╰─➤ go run cmd/chatgpt/main.go --set-completions                                                                               
flag needs an argument: --set-completions
exit status 1
```

---
##### Set completion flag with invalid arg
```
╰─➤ go run cmd/chatgpt/main.go --set-completions donno                                                                         

Usage:
  --set-completions [bash|zsh|fish|powershell]

Flags:
  -h, --help   help for --set-completions

Invalid Arg: donno
```

---
##### Set completion flag with `-h` or `--help`
```
╰─➤ go run cmd/chatgpt/main.go --set-completions -h                                                                            
To load completions:

Bash:

  $ source <(chatgpt completion bash)

  # To load completions for each session, execute once:
  # Linux:
  $ chatgpt completion bash > /etc/bash_completion.d/chatgpt
  # macOS:
  $ chatgpt completion bash > /usr/local/etc/bash_completion.d/chatgpt

Zsh:

  # If shell completion is not already enabled in your environment,
  # you will need to enable it.  You can execute the following once:

  $ echo "autoload -U compinit; compinit" >> ~/.zshrc

  # To load completions for each session, execute once:
  $ chatgpt completion zsh > "${fpath[1]}/_chatgpt"

  # You will need to start a new shell for this setup to take effect.

fish:

  $ chatgpt completion fish | source

  # To load completions for each session, execute once:
  $ chatgpt completion fish > ~/.config/fish/completions/chatgpt.fish

PowerShell:

  PS> chatgpt completion powershell | Out-String | Invoke-Expression

  # To load completions for every new session, run:
  PS> chatgpt completion powershell > chatgpt.ps1
  # and source this file from your PowerShell profile.

Usage:
  --set-completions [bash|zsh|fish|powershell]

Flags:
  -h, --help   help for --set-completions
```

---
##### Set completion flag with `zsh`, for example:
```
╰─➤ go run cmd/chatgpt/main.go --set-completions zsh   
#compdef --set-completions
compdef _--set-completions --set-completions

# zsh completion for --set-completions                    -*- shell-script -*-

__--set-completions_debug()
{
    local file="$BASH_COMP_DEBUG_FILE"
    if [[ -n ${file} ]]; then
        echo "$*" >> "${file}"
    fi
}

_--set-completions()
{
    ...
}

# don't run the completion function when being source-ed or eval-ed
if [ "$funcstack[1]" = "_--set-completions" ]; then
    _--set-completions
fi                                                                        
```