### PR TITLE
feat: support customized User-Agent header

### DIFF
--- a/api/http/http.go
+++ b/api/http/http.go
@@ -6,13 +6,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/kardolus/chatgpt-cli/api"
-	"github.com/kardolus/chatgpt-cli/config"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/kardolus/chatgpt-cli/api"
+	"github.com/kardolus/chatgpt-cli/config"
+	"go.uber.org/zap"
 )
 
 const (
@@ -23,6 +24,7 @@ const (
 	errHTTP                  = "http status %d: %s"
 	errHTTPStatus            = "http status: %d"
 	headerContentType        = "Content-Type"
+	headerUserAgent          = "User-Agent"
 )
 
 type Caller interface {
@@ -296,6 +298,7 @@ func (r *RestCaller) newRequest(method, url string, body []byte) (*http.Request,
 		req.Header.Set(r.config.AuthHeader, r.config.AuthTokenPrefix+r.config.APIKey)
 	}
 	req.Header.Set(headerContentType, contentType)
+	req.Header.Set(headerUserAgent, r.config.UserAgent)
 
 	return req, nil
 }

--- a/cmd/chatgpt/main.go
+++ b/cmd/chatgpt/main.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/kardolus/chatgpt-cli/api/client"
 	"github.com/kardolus/chatgpt-cli/api/http"
 	"github.com/kardolus/chatgpt-cli/cmd/chatgpt/utils"
@@ -11,10 +16,6 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v3"
-	"io"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/chzyer/readline"
 	"github.com/kardolus/chatgpt-cli/config"
@@ -96,6 +97,7 @@ var configMetadata = []ConfigMetadata{
 	{"name", "set-name", "openai", "The prefix for environment variable overrides"},
 	{"effort", "set-effort", "low", "Set the reasoning effort"},
 	{"voice", "set-voice", "nova", "Set the voice used by tts models"},
+	{"user_agent", "set-user-agent", "chatgpt-cli", "Set the User-Agent in request header"},
 }
 
 func init() {
@@ -943,6 +945,7 @@ func createConfigFromViper() config.Config {
 		Seed:                 viper.GetInt("seed"),
 		Effort:               viper.GetString("effort"),
 		Voice:                viper.GetString("voice"),
+		UserAgent:            viper.GetString("user_agent"),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -35,4 +35,5 @@ type Config struct {
 	Effort               string  `yaml:"effort"`
 	Voice                string  `yaml:"voice"`
 	ApifyAPIKey          string  `yaml:"apify_api_key"`
+	UserAgent            string  `yaml:"user_agent"`
 }


### PR DESCRIPTION
My llm provider blocked all requests that has a Go-http-client/1.1 user-agent string. Need this to bypass the firewall.