### PR TITLE
ci(lint): move to golangci-lint v2 for the go1.25 target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,15 @@ jobs:
     needs: format
     steps:
       - uses: actions/checkout@v4
-      - uses: golangci/golangci-lint-action@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+      # v9 installs golangci-lint v2 (built with go1.25). v3 pulled the last v1
+      # (go1.24-built), which refuses to lint this module's go1.25 target. The
+      # action runs golangci-lint itself, so no separate run step is needed.
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-      - run: golangci-lint run
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# golangci-lint v2 config. The repo moved to Go 1.25 (via a gomega bump), and
+# golangci-lint v1 (built with go1.24) can't lint a go1.25 target — so we run v2.
+#
+# v2 changed two defaults vs the v1 setup this repo linted clean under:
+#   1. it dropped the built-in exclusion list (deferred Close()/Remove() etc.)
+#   2. its unified `staticcheck` now also runs the ST (stylecheck) and QF
+#      (quickfix) checks, which v1's SA-only staticcheck never enforced.
+# Restore the prior behaviour so the existing code stays clean: keep the standard
+# exclusion presets, and limit staticcheck to the SA (real-bug) checks.
+version: "2"
+linters:
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -ST1*
+        - -QF1*


### PR DESCRIPTION
## Problem
The `test` workflow's **Lint** job is failing on `main`:

```
Error: can't load config: the Go language version (go1.24) used to build
golangci-lint is lower than the targeted Go version (1.25.0)
```

The `gomega` **v1.42.0 → v1.42.1** dependabot bump (#191) raised the module's `go` directive to **1.25.0**. The lint job used `golangci-lint-action@v3`, which installs the last **v1** golangci-lint (built with go1.24) — and v1 refuses to lint a go1.25 target. `go build` and the tests are fine; only lint breaks.

## Fix
- **`golangci-lint-action@v3` → `@v9`** (installs golangci-lint **v2**, built with go1.25), plus a `setup-go` step so it analyses against go1.25. The action runs golangci-lint itself, so the redundant `- run: golangci-lint run` is dropped.
- **Add `.golangci.yml`** to preserve the exact lint bar this repo was already clean under — v2 changed two defaults:
  1. it dropped the built-in exclusion list → restore the standard presets (deferred `Close()`/`Remove()` etc. stay non-errors);
  2. its unified `staticcheck` now also runs the **ST** (stylecheck) and **QF** (quickfix) checks that v1's SA-only staticcheck never enforced → limit `staticcheck` to the **SA** (real-bug) checks.

No source changes — the existing code stays clean.

## Verification (local, go1.25)
- `golangci-lint run` (v2.12.2): **0 issues**
- `go fmt ./...`: no diff · `go mod tidy`: `go.mod`/`go.sum` unchanged
- unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)