### PR TITLE
feat(tools): native function calling + JSON mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,27 @@ environment variables, a config.yaml file, and default values, in that respectiv
 | `url`                    | The base URL for the OpenAI API.                                                                                                                       | 'https://api.openai.com'       |
 | `user_agent`             | The header used for the user agent in API requests.                                                                                                    | 'chatgpt-cli'                  |
 | `voice`                  | The voice to use when generating audio with TTS models like gpt-4o-mini-tts.                                                                           | 'nova'                         |
+| `response_format`        | Structured output for the Chat Completions API: `json_object` for JSON mode, or a JSON Schema string to constrain the output. Empty disables it.        | ''                             |
+| `tools`                  | Enable model-driven function calling. The model can call tools advertised by the `--mcp` endpoint and the CLI feeds results back until it answers.      | `false`                        |
+| `max_tool_calls`         | Maximum number of tool-call rounds per query before giving up (guards against a model that keeps calling tools). `0` uses the built-in default of 10.   | `10`                           |
+
+### Function calling & JSON mode
+
+* **JSON mode / structured output**: pass `--json` for plain JSON output
+  (shorthand for `--response-format json_object`), or `--response-format
+  '<schema>'` / `--response-format @schema.json` to constrain output to a JSON
+  Schema. Also settable persistently via the `response_format` config. Note:
+  OpenAI's `json_object` mode requires your prompt to mention "JSON" somewhere,
+  otherwise the API rejects the request — phrase your request accordingly (a
+  JSON Schema via `--response-format` does not have this constraint).
+* **Function calling**: pass `--tools` together with `--mcp <endpoint>` to let
+  the model call that MCP server's tools autonomously. The CLI lists the
+  server's tools (`tools/list`), advertises them to the model, dispatches each
+  requested call (`tools/call`), and feeds the results back — looping until the
+  model produces a final answer (bounded by `max_tool_calls`). This is a step up
+  from the one-shot `--mcp-tool` context injection. Function calling forces
+  non-streaming (`--query`) mode, since a tool call must be received in full
+  before it can be dispatched.
 
 ### Agent Configuration
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	timer        Timer
 	reader       fsio.Reader
 	writer       fsio.Writer
+	toolExecutor ToolExecutor
 }
 
 func New(callerFactory http.CallerFactory, hs history.Store, t Timer, r fsio.Reader, w fsio.Writer, cfg config.Config) *Client {

--- a/api/client/llm.go
+++ b/api/client/llm.go
@@ -86,70 +86,65 @@ func (c *Client) ListModels() ([]string, error) {
 func (c *Client) Query(ctx context.Context, input string) (string, int, error) {
 	c.prepareQuery(input)
 
+	var (
+		response   string
+		tokensUsed int
+		err        error
+	)
+
+	if GetCapabilities(c.Config.Model).UsesResponsesAPI {
+		response, tokensUsed, err = c.queryResponses(ctx)
+	} else {
+		// The Completions path also handles model-driven tool calls (looping
+		// when tools are enabled); with tools off it is a single request.
+		response, tokensUsed, err = c.queryCompletions(ctx)
+	}
+	if err != nil {
+		return "", tokensUsed, err
+	}
+
+	c.updateHistory(response)
+
+	return response, tokensUsed, nil
+}
+
+func (c *Client) queryResponses(ctx context.Context) (string, int, error) {
 	body, err := c.createBody(ctx, false)
 	if err != nil {
 		return "", 0, err
 	}
 
 	endpoint := c.getChatEndpoint()
-
 	c.printRequestDebugInfo(endpoint, body, nil)
 
 	raw, err := c.Caller.Post(endpoint, body, false)
 	c.printResponseDebugInfo(raw)
-
 	if err != nil {
 		return "", 0, err
 	}
 
-	var (
-		response   string
-		tokensUsed int
-	)
+	var res api.ResponsesResponse
+	if err := c.processResponse(raw, &res); err != nil {
+		return "", 0, err
+	}
+	tokensUsed := res.Usage.TotalTokens
 
-	caps := GetCapabilities(c.Config.Model)
-
-	if caps.UsesResponsesAPI {
-		var res api.ResponsesResponse
-		if err := c.processResponse(raw, &res); err != nil {
-			return "", 0, err
+	var response string
+	for _, output := range res.Output {
+		if output.Type != messageType {
+			continue
 		}
-		tokensUsed = res.Usage.TotalTokens
-
-		for _, output := range res.Output {
-			if output.Type != messageType {
-				continue
+		for _, content := range output.Content {
+			if content.Type == outputTextType {
+				response = content.Text
+				break
 			}
-			for _, content := range output.Content {
-				if content.Type == outputTextType {
-					response = content.Text
-					break
-				}
-			}
-		}
-
-		if response == "" {
-			return "", tokensUsed, errors.New("no response returned")
-		}
-	} else {
-		var res api.CompletionsResponse
-		if err := c.processResponse(raw, &res); err != nil {
-			return "", 0, err
-		}
-		tokensUsed = res.Usage.TotalTokens
-
-		if len(res.Choices) == 0 {
-			return "", tokensUsed, errors.New("no responses returned")
-		}
-
-		var ok bool
-		response, ok = res.Choices[0].Message.Content.(string)
-		if !ok {
-			return "", tokensUsed, errors.New("response cannot be converted to a string")
 		}
 	}
 
-	c.updateHistory(response)
+	if response == "" {
+		return "", tokensUsed, errors.New("no response returned")
+	}
 
 	return response, tokensUsed, nil
 }
@@ -262,7 +257,54 @@ func (c *Client) createCompletionsRequest(ctx context.Context, stream bool) (*ap
 		req.TopP = c.Config.TopP
 	}
 
+	rf, err := buildResponseFormat(c.Config.ResponseFormat)
+	if err != nil {
+		return nil, err
+	}
+	req.ResponseFormat = rf
+
+	if c.toolsEnabled() {
+		defs, err := c.toolExecutor.Definitions(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load tool definitions: %w", err)
+		}
+		if len(defs) > 0 {
+			req.Tools = defs
+			req.ToolChoice = "auto"
+		}
+	}
+
 	return req, nil
+}
+
+// buildResponseFormat maps the response_format config into an API value:
+//   - ""            -> nil (no structured output)
+//   - "json_object" -> plain JSON mode
+//   - anything else -> treated as a JSON Schema and wrapped as json_schema
+func buildResponseFormat(spec string) (*api.ResponseFormat, error) {
+	spec = strings.TrimSpace(spec)
+	switch spec {
+	case "":
+		return nil, nil
+	case "json_object":
+		return &api.ResponseFormat{Type: "json_object"}, nil
+	default:
+		if !json.Valid([]byte(spec)) {
+			return nil, fmt.Errorf("response_format must be \"json_object\" or a valid JSON schema")
+		}
+		// strict:false is the safe default — OpenAI strict mode only accepts a
+		// subset of JSON Schema (objects with additionalProperties:false, all
+		// fields required, ...), so forcing it would 400 on many valid schemas.
+		wrapped, err := json.Marshal(map[string]interface{}{
+			"name":   "response",
+			"strict": false,
+			"schema": json.RawMessage(spec),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &api.ResponseFormat{Type: "json_schema", JSONSchema: wrapped}, nil
+	}
 }
 
 func (c *Client) createResponsesRequest(ctx context.Context, stream bool) (*api.ResponsesRequest, error) {

--- a/api/client/mcp_tools.go
+++ b/api/client/mcp_tools.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/kardolus/chatgpt-cli/api"
+)
+
+// MCPToolExecutor bridges an MCP server's tools to the model's function-calling
+// interface: Definitions() advertises the server's `tools/list` as function
+// definitions, and Execute() dispatches a model tool call via `tools/call`.
+// This lets the model invoke MCP tools autonomously, a step up from the
+// one-shot `--mcp-tool` context injection.
+type MCPToolExecutor struct {
+	transport MCPTransport
+	endpoint  string
+	headers   map[string]string
+}
+
+func NewMCPToolExecutor(transport MCPTransport, endpoint string, headers map[string]string) *MCPToolExecutor {
+	return &MCPToolExecutor{transport: transport, endpoint: endpoint, headers: headers}
+}
+
+func (m *MCPToolExecutor) Definitions(_ context.Context) ([]api.FunctionTool, error) {
+	req := api.MCPMessage{
+		JSONRPC: "2.0",
+		ID:      uuid.NewString(),
+		Method:  "tools/list",
+		Params:  json.RawMessage(`{}`),
+	}
+
+	resp, err := m.transport.Call(m.endpoint, req, m.headers)
+	if err != nil {
+		return nil, fmt.Errorf("mcp tools/list failed: %w", err)
+	}
+	if resp.Message.Error != nil {
+		return nil, fmt.Errorf("mcp tools/list error: %w", resp.Message.Error)
+	}
+
+	var out struct {
+		Tools []struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resp.Message.Result, &out); err != nil {
+		return nil, fmt.Errorf("mcp tools/list: cannot parse result: %w", err)
+	}
+
+	defs := make([]api.FunctionTool, 0, len(out.Tools))
+	for _, t := range out.Tools {
+		params := t.InputSchema
+		if len(params) == 0 {
+			params = json.RawMessage(`{"type":"object"}`)
+		}
+		defs = append(defs, api.FunctionTool{
+			Type: "function",
+			Function: api.FunctionDef{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  params,
+			},
+		})
+	}
+	return defs, nil
+}
+
+func (m *MCPToolExecutor) Execute(_ context.Context, name, argsJSON string) (string, error) {
+	// The model emits arguments as a JSON string; MCP tools/call requires an
+	// arguments OBJECT, so decode into a map and default to {} on empty/invalid
+	// or non-object JSON (e.g. an array or bare value).
+	args := map[string]any{}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		args = map[string]any{}
+	}
+
+	params, err := json.Marshal(map[string]any{"name": name, "arguments": args})
+	if err != nil {
+		return "", err
+	}
+
+	req := api.MCPMessage{
+		JSONRPC: "2.0",
+		ID:      uuid.NewString(),
+		Method:  "tools/call",
+		Params:  params,
+	}
+
+	resp, err := m.transport.Call(m.endpoint, req, m.headers)
+	if err != nil {
+		return "", fmt.Errorf("mcp tools/call %q failed: %w", name, err)
+	}
+	if resp.Message.Error != nil {
+		return "", fmt.Errorf("mcp tools/call %q error: %w", name, resp.Message.Error)
+	}
+
+	return extractToolResultText(resp.Message.Result), nil
+}
+
+// extractToolResultText pulls the plain text out of an MCP tools/call result
+// (the {"content":[{"type":"text","text":...}]} shape) so the model receives
+// the raw tool output as the role:"tool" content — no decorative prefix. Falls
+// back to the raw JSON when there are no text blocks.
+func extractToolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var r struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &r); err == nil && len(r.Content) > 0 {
+		var parts []string
+		for _, b := range r.Content {
+			if strings.TrimSpace(b.Text) != "" {
+				parts = append(parts, b.Text)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n")
+		}
+	}
+	return string(raw)
+}

--- a/api/client/tools.go
+++ b/api/client/tools.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kardolus/chatgpt-cli/api"
+	"github.com/kardolus/chatgpt-cli/history"
+)
+
+// defaultMaxToolCalls bounds how many tool-call rounds a single Query may run
+// before giving up, so a model that keeps calling tools can't loop forever.
+const defaultMaxToolCalls = 10
+
+// ToolExecutor advertises callable functions to the model and dispatches the
+// model's tool calls to their implementations. The MCP bridge (see
+// mcp_tools.go) is the primary implementation; tests use a stub.
+type ToolExecutor interface {
+	// Definitions returns the function definitions advertised to the model.
+	Definitions(ctx context.Context) ([]api.FunctionTool, error)
+	// Execute runs the named tool with JSON-encoded arguments and returns its
+	// textual result.
+	Execute(ctx context.Context, name, argsJSON string) (string, error)
+}
+
+// WithToolExecutor attaches a tool executor (fluent, mirrors WithTransport).
+func (c *Client) WithToolExecutor(e ToolExecutor) *Client {
+	c.toolExecutor = e
+	return c
+}
+
+// toolsEnabled reports whether model-driven function calling is active for this
+// request (config flag on AND an executor wired in).
+func (c *Client) toolsEnabled() bool {
+	return c.Config.Tools && c.toolExecutor != nil
+}
+
+func (c *Client) maxToolCalls() int {
+	if c.Config.MaxToolCalls > 0 {
+		return c.Config.MaxToolCalls
+	}
+	return defaultMaxToolCalls
+}
+
+// queryCompletions runs the Chat Completions path. Without tools it is a single
+// request; with tools enabled it loops — dispatching each round of tool calls
+// and feeding the results back — until the model returns a final answer or the
+// round budget is exhausted.
+func (c *Client) queryCompletions(ctx context.Context) (string, int, error) {
+	total := 0
+
+	// The assistant tool-call turns and role:"tool" results appended below are
+	// EPHEMERAL: they're needed in-flight for the follow-up requests, but we
+	// strip them before returning so only the user turn and the model's final
+	// answer are persisted. This keeps the saved history a valid message
+	// sequence — truncation can never orphan a role:"tool" from its assistant
+	// tool_calls turn on reload.
+	baseLen := len(c.History)
+
+	for iter := 0; ; iter++ {
+		body, err := c.createBody(ctx, false)
+		if err != nil {
+			return "", total, err
+		}
+
+		endpoint := c.getChatEndpoint()
+		c.printRequestDebugInfo(endpoint, body, nil)
+
+		raw, err := c.Caller.Post(endpoint, body, false)
+		c.printResponseDebugInfo(raw)
+		if err != nil {
+			return "", total, err
+		}
+
+		var res api.CompletionsResponse
+		if err := c.processResponse(raw, &res); err != nil {
+			return "", total, err
+		}
+		total += res.Usage.TotalTokens
+
+		if len(res.Choices) == 0 {
+			return "", total, errors.New("no responses returned")
+		}
+
+		msg := res.Choices[0].Message
+
+		// No tool calls (or tools disabled) -> this is the final answer. Drop the
+		// ephemeral tool-round messages before returning.
+		if !c.toolsEnabled() || len(msg.ToolCalls) == 0 {
+			content, ok := msg.Content.(string)
+			if !ok {
+				return "", total, errors.New("response cannot be converted to a string")
+			}
+			c.History = c.History[:baseLen]
+			return content, total, nil
+		}
+
+		if iter >= c.maxToolCalls() {
+			c.History = c.History[:baseLen]
+			return "", total, fmt.Errorf("exceeded max tool-call rounds (%d); the model kept requesting tools", c.maxToolCalls())
+		}
+
+		// Record the assistant's tool-call turn, then run each call and append
+		// its result as a role:"tool" message keyed by tool_call_id.
+		c.appendMessage(msg)
+		for _, tc := range msg.ToolCalls {
+			out, execErr := c.toolExecutor.Execute(ctx, tc.Function.Name, tc.Function.Arguments)
+			if execErr != nil {
+				// Feed the error back to the model rather than aborting the run.
+				out = fmt.Sprintf("error executing tool %q: %v", tc.Function.Name, execErr)
+			}
+			c.appendMessage(api.Message{
+				Role:       "tool",
+				ToolCallID: tc.ID,
+				Content:    out,
+			})
+		}
+	}
+}
+
+// appendMessage appends a raw message to the in-memory history without
+// truncating (used for the intermediate assistant/tool turns of a tool run).
+func (c *Client) appendMessage(msg api.Message) {
+	c.History = append(c.History, history.History{
+		Message:   msg,
+		Timestamp: c.timer.Now(),
+	})
+}

--- a/api/client/tools_test.go
+++ b/api/client/tools_test.go
@@ -1,0 +1,344 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kardolus/chatgpt-cli/api"
+	"github.com/kardolus/chatgpt-cli/api/client"
+	"github.com/kardolus/chatgpt-cli/api/http"
+	config2 "github.com/kardolus/chatgpt-cli/config"
+	"github.com/kardolus/chatgpt-cli/history"
+	"github.com/kardolus/chatgpt-cli/internal/fsio"
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+// --- test doubles -----------------------------------------------------------
+
+// scriptCaller returns queued Post responses in order and records the request
+// bodies it was given, so multi-turn tool round-trips can be scripted.
+type scriptCaller struct {
+	responses [][]byte
+	errs      []error
+	bodies    [][]byte
+	calls     int
+}
+
+func (s *scriptCaller) Post(_ string, body []byte, _ bool) ([]byte, error) {
+	s.bodies = append(s.bodies, body)
+	i := s.calls
+	s.calls++
+	var err error
+	if i < len(s.errs) {
+		err = s.errs[i]
+	}
+	if i < len(s.responses) {
+		return s.responses[i], err
+	}
+	return nil, err
+}
+func (s *scriptCaller) PostWithHeaders(_ string, _ []byte, _ map[string]string) ([]byte, error) {
+	return nil, nil
+}
+func (s *scriptCaller) Get(_ string) ([]byte, error) { return nil, nil }
+func (s *scriptCaller) PostWithHeadersResponse(_ string, _ []byte, _ map[string]string) (api.HTTPResponse, error) {
+	return api.HTTPResponse{}, nil
+}
+
+type stubExec struct {
+	defs    []api.FunctionTool
+	results []string
+	errs    []error
+	calls   []stubCall
+}
+type stubCall struct{ name, args string }
+
+func (e *stubExec) Definitions(context.Context) ([]api.FunctionTool, error) { return e.defs, nil }
+func (e *stubExec) Execute(_ context.Context, name, args string) (string, error) {
+	i := len(e.calls)
+	e.calls = append(e.calls, stubCall{name, args})
+	var err error
+	if i < len(e.errs) {
+		err = e.errs[i]
+	}
+	res := "ok"
+	if i < len(e.results) {
+		res = e.results[i]
+	}
+	return res, err
+}
+
+type nopStore struct{}
+
+func (nopStore) Read() ([]history.History, error)             { return nil, nil }
+func (nopStore) ReadThread(string) ([]history.History, error) { return nil, nil }
+func (nopStore) Write([]history.History) error                { return nil }
+func (nopStore) SetThread(string)                             {}
+func (nopStore) GetThread() string                            { return "" }
+
+type zeroTimer struct{}
+
+func (zeroTimer) Now() time.Time { return time.Time{} }
+
+func buildToolClient(caller http.Caller, exec client.ToolExecutor, cfg config2.Config) *client.Client {
+	c := client.New(
+		func(config2.Config) http.Caller { return caller },
+		nopStore{},
+		zeroTimer{},
+		fsio.NewRealReader(fsio.DefaultBufferSize),
+		&fsio.RealWriter{},
+		cfg,
+	)
+	if exec != nil {
+		c = c.WithToolExecutor(exec)
+	}
+	return c
+}
+
+// canned responses
+const (
+	toolCallResp = `{"choices":[{"message":{"role":"assistant","content":null,` +
+		`"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"NYC\"}"}}]},` +
+		`"finish_reason":"tool_calls"}],"usage":{"total_tokens":10}}`
+	finalResp = `{"choices":[{"message":{"role":"assistant","content":"It is sunny."}}],"usage":{"total_tokens":5}}`
+)
+
+func weatherTool() api.FunctionTool {
+	return api.FunctionTool{
+		Type:     "function",
+		Function: api.FunctionDef{Name: "get_weather", Description: "get weather", Parameters: json.RawMessage(`{"type":"object"}`)},
+	}
+}
+
+func TestUnitFunctionCalling(t *testing.T) {
+	spec.Run(t, "Testing function calling + JSON mode", testFunctionCalling, spec.Report(report.Terminal{}))
+}
+
+func testFunctionCalling(t *testing.T, when spec.G, it spec.S) {
+	it.Before(func() { RegisterTestingT(t) })
+
+	baseCfg := func() config2.Config {
+		return config2.Config{Model: "gpt-4o", OmitHistory: true}
+	}
+
+	when("JSON mode (response_format)", func() {
+		it("sends json_object when configured", func() {
+			cfg := baseCfg()
+			cfg.ResponseFormat = "json_object"
+			caller := &scriptCaller{responses: [][]byte{[]byte(finalResp)}}
+
+			_, _, err := buildToolClient(caller, nil, cfg).Query(context.Background(), "hi")
+			Expect(err).NotTo(HaveOccurred())
+
+			var req api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[0], &req)).To(Succeed())
+			Expect(req.ResponseFormat).NotTo(BeNil())
+			Expect(req.ResponseFormat.Type).To(Equal("json_object"))
+		})
+
+		it("wraps a JSON schema as json_schema", func() {
+			cfg := baseCfg()
+			cfg.ResponseFormat = `{"type":"object","properties":{"x":{"type":"number"}}}`
+			caller := &scriptCaller{responses: [][]byte{[]byte(finalResp)}}
+
+			_, _, err := buildToolClient(caller, nil, cfg).Query(context.Background(), "hi")
+			Expect(err).NotTo(HaveOccurred())
+
+			var req api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[0], &req)).To(Succeed())
+			Expect(req.ResponseFormat).NotTo(BeNil())
+			Expect(req.ResponseFormat.Type).To(Equal("json_schema"))
+			Expect(string(req.ResponseFormat.JSONSchema)).To(ContainSubstring(`"strict":false`))
+			Expect(string(req.ResponseFormat.JSONSchema)).To(ContainSubstring(`"schema"`))
+		})
+
+		it("errors on an invalid schema", func() {
+			cfg := baseCfg()
+			cfg.ResponseFormat = "not json{"
+			caller := &scriptCaller{responses: [][]byte{[]byte(finalResp)}}
+
+			_, _, err := buildToolClient(caller, nil, cfg).Query(context.Background(), "hi")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("json_object"))
+		})
+
+		it("omits response_format when unset", func() {
+			caller := &scriptCaller{responses: [][]byte{[]byte(finalResp)}}
+			_, _, err := buildToolClient(caller, nil, baseCfg()).Query(context.Background(), "hi")
+			Expect(err).NotTo(HaveOccurred())
+			var req api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[0], &req)).To(Succeed())
+			Expect(req.ResponseFormat).To(BeNil())
+		})
+	})
+
+	when("function-calling round-trip", func() {
+		it("advertises tools, dispatches the call, feeds the result back, and returns the final answer", func() {
+			cfg := baseCfg()
+			cfg.Tools = true
+			exec := &stubExec{defs: []api.FunctionTool{weatherTool()}, results: []string{"sunny, 75F"}}
+			caller := &scriptCaller{responses: [][]byte{[]byte(toolCallResp), []byte(finalResp)}}
+
+			c := buildToolClient(caller, exec, cfg)
+			out, tokens, err := c.Query(context.Background(), "weather in NYC?")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(Equal("It is sunny."))
+			Expect(tokens).To(Equal(15)) // 10 + 5 across both rounds
+
+			// The ephemeral tool-round messages must NOT persist: history is just
+			// the user turn + the final answer (no orphan-able role:"tool" msgs).
+			var roles []string
+			for _, h := range c.History {
+				roles = append(roles, h.Message.Role)
+			}
+			Expect(roles).To(Equal([]string{"user", "assistant"}))
+
+			// The tool was dispatched with the model's name + args.
+			Expect(exec.calls).To(HaveLen(1))
+			Expect(exec.calls[0].name).To(Equal("get_weather"))
+			Expect(exec.calls[0].args).To(Equal(`{"city":"NYC"}`))
+
+			// Two requests were made.
+			Expect(caller.bodies).To(HaveLen(2))
+
+			// Request 1 advertises the tool with tool_choice=auto.
+			var req0 api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[0], &req0)).To(Succeed())
+			Expect(req0.Tools).To(HaveLen(1))
+			Expect(req0.Tools[0].Function.Name).To(Equal("get_weather"))
+			Expect(req0.ToolChoice).To(Equal("auto"))
+
+			// Request 2 carries the assistant tool-call turn + the tool result.
+			var req1 api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[1], &req1)).To(Succeed())
+			var sawToolResult bool
+			for _, m := range req1.Messages {
+				if m.Role == "tool" && m.ToolCallID == "call_1" {
+					sawToolResult = true
+					Expect(m.Content).To(Equal("sunny, 75F"))
+				}
+			}
+			Expect(sawToolResult).To(BeTrue())
+		})
+
+		it("does not advertise tools when the config flag is off", func() {
+			cfg := baseCfg() // Tools=false
+			exec := &stubExec{defs: []api.FunctionTool{weatherTool()}}
+			caller := &scriptCaller{responses: [][]byte{[]byte(finalResp)}}
+
+			_, _, err := buildToolClient(caller, exec, cfg).Query(context.Background(), "hi")
+			Expect(err).NotTo(HaveOccurred())
+			var req api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[0], &req)).To(Succeed())
+			Expect(req.Tools).To(BeEmpty())
+			Expect(exec.calls).To(BeEmpty())
+		})
+
+		it("feeds an execution error back to the model instead of aborting", func() {
+			cfg := baseCfg()
+			cfg.Tools = true
+			exec := &stubExec{defs: []api.FunctionTool{weatherTool()}, errs: []error{context.DeadlineExceeded}}
+			caller := &scriptCaller{responses: [][]byte{[]byte(toolCallResp), []byte(finalResp)}}
+
+			out, _, err := buildToolClient(caller, exec, cfg).Query(context.Background(), "hi")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(Equal("It is sunny."))
+
+			var req1 api.CompletionsRequest
+			Expect(json.Unmarshal(caller.bodies[1], &req1)).To(Succeed())
+			var toolMsg string
+			for _, m := range req1.Messages {
+				if m.Role == "tool" {
+					toolMsg, _ = m.Content.(string)
+				}
+			}
+			Expect(toolMsg).To(ContainSubstring("error executing tool"))
+		})
+
+		it("bounds the number of tool-call rounds", func() {
+			cfg := baseCfg()
+			cfg.Tools = true
+			cfg.MaxToolCalls = 2
+			exec := &stubExec{defs: []api.FunctionTool{weatherTool()}}
+			// Always returns a tool call -> would loop forever without the bound.
+			caller := &scriptCaller{responses: [][]byte{
+				[]byte(toolCallResp), []byte(toolCallResp), []byte(toolCallResp), []byte(toolCallResp),
+			}}
+
+			_, _, err := buildToolClient(caller, exec, cfg).Query(context.Background(), "hi")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("max tool-call rounds"))
+		})
+	})
+
+	when("MCP tool bridge", func() {
+		it("advertises tools/list as function definitions", func() {
+			tr := &fakeTransport{listResult: json.RawMessage(
+				`{"tools":[{"name":"get_weather","description":"gets weather","inputSchema":{"type":"object","properties":{"city":{"type":"string"}}}}]}`)}
+
+			defs, err := client.NewMCPToolExecutor(tr, "http://mcp", nil).Definitions(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(defs).To(HaveLen(1))
+			Expect(defs[0].Type).To(Equal("function"))
+			Expect(defs[0].Function.Name).To(Equal("get_weather"))
+			Expect(defs[0].Function.Description).To(Equal("gets weather"))
+			Expect(string(defs[0].Function.Parameters)).To(ContainSubstring("city"))
+			Expect(tr.lastCall.Method).To(Equal("tools/list"))
+		})
+
+		it("defaults an object schema when a tool omits inputSchema", func() {
+			tr := &fakeTransport{listResult: json.RawMessage(`{"tools":[{"name":"ping"}]}`)}
+			defs, err := client.NewMCPToolExecutor(tr, "http://mcp", nil).Definitions(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(defs[0].Function.Parameters)).To(Equal(`{"type":"object"}`))
+		})
+
+		it("dispatches a tool call via tools/call and returns the text result", func() {
+			tr := &fakeTransport{callResult: json.RawMessage(`{"content":[{"type":"text","text":"sunny, 75F"}]}`)}
+
+			out, err := client.NewMCPToolExecutor(tr, "http://mcp", nil).
+				Execute(context.Background(), "get_weather", `{"city":"NYC"}`)
+			Expect(err).NotTo(HaveOccurred())
+			// Raw text result, no decorative "[MCP: ...]" prefix.
+			Expect(out).To(Equal("sunny, 75F"))
+
+			Expect(tr.lastCall.Method).To(Equal("tools/call"))
+			Expect(string(tr.lastCall.Params)).To(ContainSubstring(`"name":"get_weather"`))
+			Expect(string(tr.lastCall.Params)).To(ContainSubstring(`"city":"NYC"`))
+		})
+
+		it("coerces empty/invalid/non-object arguments to an empty object", func() {
+			for _, args := range []string{"", "not json", "[1,2,3]", `"scalar"`, "42"} {
+				tr := &fakeTransport{callResult: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}
+				_, err := client.NewMCPToolExecutor(tr, "http://mcp", nil).
+					Execute(context.Background(), "ping", args)
+				Expect(err).NotTo(HaveOccurred(), args)
+				Expect(string(tr.lastCall.Params)).To(ContainSubstring(`"arguments":{}`), args)
+			}
+		})
+	})
+}
+
+// fakeTransport is an in-memory MCPTransport returning canned tools/list and
+// tools/call results based on the request method.
+type fakeTransport struct {
+	listResult json.RawMessage
+	callResult json.RawMessage
+	lastCall   api.MCPMessage
+}
+
+func (f *fakeTransport) Call(_ string, req api.MCPMessage, _ map[string]string) (api.MCPResponse, error) {
+	f.lastCall = req
+	var result json.RawMessage
+	switch req.Method {
+	case "tools/list":
+		result = f.listResult
+	case "tools/call":
+		result = f.callResult
+	}
+	return api.MCPResponse{Message: api.MCPMessage{Result: result}}, nil
+}

--- a/api/completions.go
+++ b/api/completions.go
@@ -14,21 +14,61 @@ func (f Float64) MarshalJSON() ([]byte, error) {
 }
 
 type CompletionsRequest struct {
-	Model            string    `json:"model"`
-	Temperature      float64   `json:"temperature,omitempty"`
-	TopP             float64   `json:"top_p,omitempty"`
-	FrequencyPenalty float64   `json:"frequency_penalty,omitempty"`
-	MaxTokens        int       `json:"max_completion_tokens"`
-	PresencePenalty  float64   `json:"presence_penalty,omitempty"`
-	Messages         []Message `json:"messages"`
-	Stream           bool      `json:"stream"`
-	Seed             int       `json:"seed,omitempty"`
+	Model            string          `json:"model"`
+	Temperature      float64         `json:"temperature,omitempty"`
+	TopP             float64         `json:"top_p,omitempty"`
+	FrequencyPenalty float64         `json:"frequency_penalty,omitempty"`
+	MaxTokens        int             `json:"max_completion_tokens"`
+	PresencePenalty  float64         `json:"presence_penalty,omitempty"`
+	Messages         []Message       `json:"messages"`
+	Stream           bool            `json:"stream"`
+	Seed             int             `json:"seed,omitempty"`
+	Tools            []FunctionTool  `json:"tools,omitempty"`
+	ToolChoice       interface{}     `json:"tool_choice,omitempty"`
+	ResponseFormat   *ResponseFormat `json:"response_format,omitempty"`
 }
 
 type Message struct {
 	Role    string      `json:"role"`
 	Name    string      `json:"name,omitempty"`
 	Content interface{} `json:"content"`
+	// ToolCalls is set on an assistant message when the model wants to invoke
+	// functions; ToolCallID links a role:"tool" result back to its call.
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+// FunctionTool advertises a callable function to the model (the OpenAI
+// tools=[{type:"function", function:{...}}] shape). Distinct from the
+// web-search Tool used by the Responses API.
+type FunctionTool struct {
+	Type     string      `json:"type"` // always "function"
+	Function FunctionDef `json:"function"`
+}
+
+type FunctionDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"` // JSON Schema
+}
+
+// ToolCall is a function invocation the model emitted in its response.
+type ToolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"` // "function"
+	Function FunctionCall `json:"function"`
+}
+
+type FunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON-encoded arguments
+}
+
+// ResponseFormat drives JSON mode / structured output. Type is typically
+// "json_object" or "json_schema"; JSONSchema carries the schema for the latter.
+type ResponseFormat struct {
+	Type       string          `json:"type"`
+	JSONSchema json.RawMessage `json:"json_schema,omitempty"`
 }
 
 type AudioContent struct {

--- a/cmd/chatgpt/flags.go
+++ b/cmd/chatgpt/flags.go
@@ -105,6 +105,9 @@ func setupFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().StringArrayVar(&paramsList, "mcp-param", []string{}, "Key-value pair as key=value. Can be specified multiple times")
 	rootCmd.PersistentFlags().StringVar(&paramsJSON, "mcp-params", "", "Provide parameters as a raw JSON string")
 	rootCmd.PersistentFlags().BoolVar(&agentEnabled, "agent", false, "Run agent (experimental)")
+	rootCmd.PersistentFlags().BoolVar(&jsonMode, "json", false, "Request JSON output (shorthand for --response-format json_object)")
+	rootCmd.PersistentFlags().StringVar(&responseFormat, "response-format", "", "Structured output: 'json_object', a JSON schema, or @file with a schema")
+	rootCmd.PersistentFlags().BoolVar(&toolsFlag, "tools", false, "Let the model call tools from the --mcp endpoint (function calling)")
 }
 
 func setupConfigFlags(rootCmd *cobra.Command, meta ConfigMetadata) {

--- a/cmd/chatgpt/main.go
+++ b/cmd/chatgpt/main.go
@@ -43,6 +43,9 @@ var (
 	modelTarget     string
 	paramsList      []string
 	paramsJSON      string
+	jsonMode        bool
+	responseFormat  string
+	toolsFlag       bool
 	cfg             config.Config
 )
 

--- a/cmd/chatgpt/run.go
+++ b/cmd/chatgpt/run.go
@@ -192,6 +192,28 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Structured-output (JSON mode) + function-calling flags override config.
+	if jsonMode {
+		cfg.ResponseFormat = "json_object"
+	}
+	if cmd.Flag("response-format").Changed {
+		rf := responseFormat
+		if strings.HasPrefix(rf, "@") {
+			data, err := os.ReadFile(rf[1:])
+			if err != nil {
+				return fmt.Errorf("failed to read response-format schema: %w", err)
+			}
+			rf = string(data)
+		}
+		cfg.ResponseFormat = rf
+	}
+	if toolsFlag {
+		cfg.Tools = true
+		// Tool round-trips need the full response before dispatching, so force
+		// non-streaming when function calling is enabled.
+		queryMode = true
+	}
+
 	c := client.New(http.RealCallerFactory, hs, &client.RealTime{}, fsio.NewRealReader(fsio.DefaultBufferSize), &fsio.RealWriter{}, cfg)
 
 	if ServiceURL != "" {
@@ -266,7 +288,28 @@ func run(cmd *cobra.Command, args []string) error {
 		queryMode = true
 	}
 
-	if cmd.Flag("mcp").Changed {
+	// Function-calling: expose the MCP endpoint's tools to the model so it can
+	// call them autonomously (distinct from the one-shot --mcp-tool injection).
+	if toolsFlag {
+		if mcpEndpoint == "" {
+			return errors.New("--tools requires an --mcp endpoint to source tools from")
+		}
+
+		headers, err := utils.ParseMCPHeaders(mcpHeaders)
+		if err != nil {
+			return err
+		}
+
+		transport, err := buildMCPSessionTransport(c.Caller, mcpEndpoint, headers)
+		if err != nil {
+			return err
+		}
+
+		c = c.WithTransport(transport).
+			WithToolExecutor(client.NewMCPToolExecutor(transport, mcpEndpoint, headers))
+	}
+
+	if cmd.Flag("mcp").Changed && !toolsFlag {
 		if mcpEndpoint == "" {
 			return errors.New("--mcp is required")
 		}
@@ -305,22 +348,10 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		base, err := client.NewMCPTransport(mcp.Endpoint, c.Caller, mcp.Headers)
+		transport, err := buildMCPSessionTransport(c.Caller, mcp.Endpoint, mcp.Headers)
 		if err != nil {
 			return err
 		}
-
-		cacheHome, err := internal.GetCacheHome()
-		if err != nil {
-			return err
-		}
-
-		sessionsDir := filepath.Join(cacheHome, "mcp", "sessions")
-
-		store := cache.NewFileStore(sessionsDir)
-		sessionStore := cache.New(store)
-
-		transport := client.NewSessionTransport(base, sessionStore)
 
 		c = c.WithTransport(transport)
 
@@ -565,4 +596,21 @@ func setShellTitle(title string) error {
 	}
 
 	return nil
+}
+
+// buildMCPSessionTransport wires the HTTP MCP transport behind the session
+// cache. Shared by the one-shot --mcp-tool injection and the --tools bridge.
+func buildMCPSessionTransport(caller http.Caller, endpoint string, headers map[string]string) (client.MCPTransport, error) {
+	base, err := client.NewMCPTransport(endpoint, caller, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheHome, err := internal.GetCacheHome()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionStore := cache.New(cache.NewFileStore(filepath.Join(cacheHome, "mcp", "sessions")))
+	return client.NewSessionTransport(base, sessionStore), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	Effort               string            `yaml:"effort"`
 	Voice                string            `yaml:"voice"`
 	UserAgent            string            `yaml:"user_agent"`
+	ResponseFormat       string            `yaml:"response_format"`
+	Tools                bool              `yaml:"tools"`
+	MaxToolCalls         int               `yaml:"max_tool_calls"`
 	CustomHeaders        map[string]string `yaml:"custom_headers"`
 	Agent                AgentConfig       `yaml:"agent"`
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -492,6 +492,17 @@ func testIntegration(t *testing.T, when spec.G, it spec.S) {
 			Expect(output).To(ContainSubstring("flag needs an argument: --set-thread"))
 		})
 
+		it("should require an --mcp endpoint when --tools is set", func() {
+			command := exec.Command(binaryPath, "--tools", "--query", "hi")
+			session, err := gexec.Start(command, io.Discard, io.Discard)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(exitFailure))
+
+			output := string(session.Err.Contents())
+			Expect(output).To(ContainSubstring("--tools requires an --mcp endpoint"))
+		})
+
 		it("should require an argument for the --set-max-tokens flag", func() {
 			command := exec.Command(binaryPath, "--set-max-tokens")
 			session, err := gexec.Start(command, io.Discard, io.Discard)


### PR DESCRIPTION
## Track C — native function calling + JSON mode

The last of the four tracks. Adds model-driven **function calling** and **structured output** to the Chat Completions path.

### JSON mode / structured output
- `CompletionsRequest` gains `ResponseFormat`. Drive it with `--json` (shorthand for `--response-format json_object`) or `--response-format '<schema>'` / `@schema.json`; persist via the `response_format` config.
- A JSON Schema is wrapped as `{type:json_schema, json_schema:{name, strict:false, schema}}` (see review note on `strict`).

### Function calling
- New API types `FunctionTool`/`FunctionDef`/`ToolCall`/`FunctionCall` (named to avoid colliding with the web-search `Tool` on the Responses API); `Message` gains `ToolCalls`/`ToolCallID`.
- A `ToolExecutor` interface + a **non-streaming tool-call round-trip**: advertise tools → on `tool_calls`, dispatch each, feed results back as `role:"tool"` messages, re-request until a final answer or the `max_tool_calls` bound (default 10).
- **`MCPToolExecutor`** bridges an MCP server: `tools/list` → function defs, model tool calls → `tools/call`. Enabled with `--tools` (requires `--mcp`; forces non-streaming). A real step up from the one-shot `--mcp-tool` injection.

### Deferred
Streaming + tool calls (accumulating tool-call deltas mid-stream) — tool use inherently needs the full call before dispatch. Noted as a follow-up.

### Cross-model review (GPT-5.5 + Grok + Gemini)
All three reviewed; the consensus fixes are already applied:
- **Ephemeral tool-round history** — all three flagged that persisting the intermediate `assistant(tool_calls)` + `role:"tool"` messages risks an *invalid* sequence on reload (truncation could orphan a tool result from its assistant turn). Fix: the tool-round messages are stripped before returning, so only the user turn + final answer persist. A unit test locks in `history == [user, assistant]`.
- **`strict:false`** default for JSON schema — arbitrary user schemas aren't all strict-compatible (would 400).
- **MCP result = raw text** (no `[MCP: name]` prefix that would confuse the model).
- **MCP arguments coerced to a JSON object** (`[]`/`"x"`/`123` are valid JSON but invalid args).

### Tests
13 unit specs (JSON mode, schema wrapping, the round-trip incl. the ephemeral-history invariant, tools-off, error feed-back, round bound, MCP `Definitions`/`Execute`) + an integration guard that `--tools` requires `--mcp`. `make unit` + `make integration` green; **no new dependencies**.