### PR TITLE
feat(cancel): graceful Ctrl-C via context cancellation

### DIFF
--- a/agent/tools/llm_test.go
+++ b/agent/tools/llm_test.go
@@ -24,14 +24,14 @@ type fakeCaller struct {
 	postErr  error
 }
 
-func (f *fakeCaller) Post(_ string, _ []byte, _ bool) ([]byte, error) {
+func (f *fakeCaller) Post(_ context.Context, _ string, _ []byte, _ bool) ([]byte, error) {
 	return f.postResp, f.postErr
 }
-func (f *fakeCaller) PostWithHeaders(_ string, _ []byte, _ map[string]string) ([]byte, error) {
+func (f *fakeCaller) PostWithHeaders(_ context.Context, _ string, _ []byte, _ map[string]string) ([]byte, error) {
 	return f.postResp, f.postErr
 }
-func (f *fakeCaller) Get(_ string) ([]byte, error) { return nil, nil }
-func (f *fakeCaller) PostWithHeadersResponse(_ string, _ []byte, _ map[string]string) (api.HTTPResponse, error) {
+func (f *fakeCaller) Get(_ context.Context, _ string) ([]byte, error) { return nil, nil }
+func (f *fakeCaller) PostWithHeadersResponse(_ context.Context, _ string, _ []byte, _ map[string]string) (api.HTTPResponse, error) {
 	return api.HTTPResponse{}, nil
 }
 

--- a/api/client/callermocks_test.go
+++ b/api/client/callermocks_test.go
@@ -5,6 +5,7 @@
 package client_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,61 +36,61 @@ func (m *MockCaller) EXPECT() *MockCallerMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockCaller) Get(arg0 string) ([]byte, error) {
+func (m *MockCaller) Get(arg0 context.Context, arg1 string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockCallerMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockCallerMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCaller)(nil).Get), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCaller)(nil).Get), arg0, arg1)
 }
 
 // Post mocks base method.
-func (m *MockCaller) Post(arg0 string, arg1 []byte, arg2 bool) ([]byte, error) {
+func (m *MockCaller) Post(arg0 context.Context, arg1 string, arg2 []byte, arg3 bool) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Post", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Post", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Post indicates an expected call of Post.
-func (mr *MockCallerMockRecorder) Post(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCallerMockRecorder) Post(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockCaller)(nil).Post), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockCaller)(nil).Post), arg0, arg1, arg2, arg3)
 }
 
 // PostWithHeaders mocks base method.
-func (m *MockCaller) PostWithHeaders(arg0 string, arg1 []byte, arg2 map[string]string) ([]byte, error) {
+func (m *MockCaller) PostWithHeaders(arg0 context.Context, arg1 string, arg2 []byte, arg3 map[string]string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostWithHeaders", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PostWithHeaders", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PostWithHeaders indicates an expected call of PostWithHeaders.
-func (mr *MockCallerMockRecorder) PostWithHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCallerMockRecorder) PostWithHeaders(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostWithHeaders", reflect.TypeOf((*MockCaller)(nil).PostWithHeaders), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostWithHeaders", reflect.TypeOf((*MockCaller)(nil).PostWithHeaders), arg0, arg1, arg2, arg3)
 }
 
 // PostWithHeadersResponse mocks base method.
-func (m *MockCaller) PostWithHeadersResponse(arg0 string, arg1 []byte, arg2 map[string]string) (api.HTTPResponse, error) {
+func (m *MockCaller) PostWithHeadersResponse(arg0 context.Context, arg1 string, arg2 []byte, arg3 map[string]string) (api.HTTPResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostWithHeadersResponse", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PostWithHeadersResponse", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(api.HTTPResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PostWithHeadersResponse indicates an expected call of PostWithHeadersResponse.
-func (mr *MockCallerMockRecorder) PostWithHeadersResponse(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCallerMockRecorder) PostWithHeadersResponse(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostWithHeadersResponse", reflect.TypeOf((*MockCaller)(nil).PostWithHeadersResponse), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostWithHeadersResponse", reflect.TypeOf((*MockCaller)(nil).PostWithHeadersResponse), arg0, arg1, arg2, arg3)
 }

--- a/api/client/llm.go
+++ b/api/client/llm.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kardolus/chatgpt-cli/api"
-	"github.com/kardolus/chatgpt-cli/history"
 	"sort"
 	"strings"
+
+	"github.com/kardolus/chatgpt-cli/api"
+	"github.com/kardolus/chatgpt-cli/history"
 )
 
 const (
@@ -38,7 +39,7 @@ func (c *Client) ListModels() ([]string, error) {
 
 	c.printRequestDebugInfo(endpoint, nil, nil)
 
-	raw, err := c.Caller.Get(c.getEndpoint(c.Config.ModelsPath))
+	raw, err := c.Caller.Get(context.Background(), c.getEndpoint(c.Config.ModelsPath))
 	c.printResponseDebugInfo(raw)
 
 	if err != nil {
@@ -117,7 +118,7 @@ func (c *Client) queryResponses(ctx context.Context) (string, int, error) {
 	endpoint := c.getChatEndpoint()
 	c.printRequestDebugInfo(endpoint, body, nil)
 
-	raw, err := c.Caller.Post(endpoint, body, false)
+	raw, err := c.Caller.Post(ctx, endpoint, body, false)
 	c.printResponseDebugInfo(raw)
 	if err != nil {
 		return "", 0, err
@@ -175,7 +176,7 @@ func (c *Client) Stream(ctx context.Context, input string) error {
 
 	c.printRequestDebugInfo(endpoint, body, nil)
 
-	result, err := c.Caller.Post(endpoint, body, true)
+	result, err := c.Caller.Post(ctx, endpoint, body, true)
 	if err != nil {
 		return err
 	}

--- a/api/client/llm_test.go
+++ b/api/client/llm_test.go
@@ -117,7 +117,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+subject.Config.CompletionsPath, body, false).
+						Post(gomock.Any(), subject.Config.URL+subject.Config.CompletionsPath, body, false).
 						Return(respBytes, tt.postError)
 
 					mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
@@ -137,7 +137,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				config.Model = realtimeModel
 
 				mockCaller.EXPECT().
-					Post(gomock.Any(), gomock.Any(), gomock.Any()).
+					Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 				mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
@@ -156,7 +156,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				subject.Config.Web = true
 
 				mockCaller.EXPECT().
-					Post(gomock.Any(), gomock.Any(), gomock.Any()).
+					Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 				mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
@@ -174,7 +174,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				subject.Config.Web = true
 
 				mockCaller.EXPECT().
-					Post(gomock.Any(), gomock.Any(), gomock.Any()).
+					Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 				mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
@@ -216,7 +216,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+subject.Config.CompletionsPath, expectedBody, false).
+						Post(gomock.Any(), subject.Config.URL+subject.Config.CompletionsPath, expectedBody, false).
 						Return(respBytes, nil)
 
 					var request api.CompletionsRequest
@@ -299,8 +299,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
 
 					mockCaller.EXPECT().
-						Post(gomock.Any(), gomock.Any(), gomock.Any()).
-						DoAndReturn(func(endpoint string, body []byte, stream bool) ([]byte, error) {
+						Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						DoAndReturn(func(_ context.Context, endpoint string, body []byte, stream bool) ([]byte, error) {
 							capturedBody = body
 							return validHTTPResponseBytes, nil
 						})
@@ -370,7 +370,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 
 					mockTimer.EXPECT().Now().Return(time.Now()).AnyTimes()
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+subject.Config.CompletionsPath, expectedBody, false).
+						Post(gomock.Any(), subject.Config.URL+subject.Config.CompletionsPath, expectedBody, false).
 						Return(nil, nil)
 
 					_, _, _ = subject.Query(context.Background(), "test query")
@@ -400,7 +400,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 
 					mockTimer.EXPECT().Now().Return(time.Now()).AnyTimes()
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+subject.Config.CompletionsPath, expectedBody, false).
+						Post(gomock.Any(), subject.Config.URL+subject.Config.CompletionsPath, expectedBody, false).
 						Return(nil, nil)
 
 					_, _, _ = subject.Query(context.Background(), "test query")
@@ -421,8 +421,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					mockTimer.EXPECT().Now().Return(time.Now()).AnyTimes()
 
 					mockCaller.EXPECT().
-						Post(gomock.Any(), gomock.Any(), false).
-						DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+						Post(gomock.Any(), gomock.Any(), gomock.Any(), false).
+						DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 							var req map[string]interface{}
 							Expect(json.Unmarshal(body, &req)).To(Succeed())
 							Expect(req).NotTo(HaveKey("temperature"))
@@ -448,8 +448,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					mockTimer.EXPECT().Now().Return(time.Now()).AnyTimes()
 
 					mockCaller.EXPECT().
-						Post(gomock.Any(), gomock.Any(), false).
-						DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+						Post(gomock.Any(), gomock.Any(), gomock.Any(), false).
+						DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 							var req map[string]interface{}
 							Expect(json.Unmarshal(body, &req)).To(Succeed())
 
@@ -482,8 +482,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					raw, _ := json.Marshal(response)
 
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+"/v1/responses", gomock.Any(), false).
-						DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+						Post(gomock.Any(), subject.Config.URL+"/v1/responses", gomock.Any(), false).
+						DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 							var req map[string]any
 							Expect(json.Unmarshal(body, &req)).To(Succeed())
 							Expect(req).To(HaveKey("tools"))
@@ -515,8 +515,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					raw, _ := json.Marshal(response)
 
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+"/v1/responses", gomock.Any(), false).
-						DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+						Post(gomock.Any(), subject.Config.URL+"/v1/responses", gomock.Any(), false).
+						DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 							var req map[string]any
 							Expect(json.Unmarshal(body, &req)).To(Succeed())
 
@@ -619,8 +619,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 							raw, _ := json.Marshal(response)
 
 							mockCaller.EXPECT().
-								Post(subject.Config.URL+"/v1/responses", gomock.Any(), false).
-								DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+								Post(gomock.Any(), subject.Config.URL+"/v1/responses", gomock.Any(), false).
+								DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 									assertResponsesRequest(body)
 									return raw, nil
 								})
@@ -645,8 +645,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 							raw, _ := json.Marshal(response)
 
 							mockCaller.EXPECT().
-								Post(subject.Config.URL+"/v1/responses", gomock.Any(), false).
-								DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+								Post(gomock.Any(), subject.Config.URL+"/v1/responses", gomock.Any(), false).
+								DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 									assertResponsesRequest(body)
 									return raw, nil
 								})
@@ -673,8 +673,8 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 							raw, _ := json.Marshal(response)
 
 							mockCaller.EXPECT().
-								Post(subject.Config.URL+"/v1/responses", gomock.Any(), false).
-								DoAndReturn(func(_ string, body []byte, _ bool) ([]byte, error) {
+								Post(gomock.Any(), subject.Config.URL+"/v1/responses", gomock.Any(), false).
+								DoAndReturn(func(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 									assertResponsesRequest(body)
 									return raw, nil
 								})
@@ -705,7 +705,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 
 				errorMsg := "error message"
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.CompletionsPath, body, true).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.CompletionsPath, body, true).
 					Return(nil, errors.New(errorMsg))
 
 				mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
@@ -724,7 +724,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				config.Model = realtimeModel
 
 				mockCaller.EXPECT().
-					Post(gomock.Any(), gomock.Any(), gomock.Any()).
+					Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 				mockTimer.EXPECT().Now().Return(time.Time{}).Times(2)
@@ -743,7 +743,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					mockCaller.EXPECT().
-						Post(subject.Config.URL+subject.Config.CompletionsPath, expectedBody, true).
+						Post(gomock.Any(), subject.Config.URL+subject.Config.CompletionsPath, expectedBody, true).
 						Return([]byte(answer), nil)
 
 					mockTimer.EXPECT().Now().Return(time.Time{}).AnyTimes()
@@ -800,7 +800,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				subject := factory.buildClientWithoutConfig()
 
 				errorMsg := "error message"
-				mockCaller.EXPECT().Get(subject.Config.URL+subject.Config.ModelsPath).
+				mockCaller.EXPECT().Get(gomock.Any(), subject.Config.URL+subject.Config.ModelsPath).
 					Return(nil, errors.New(errorMsg))
 
 				_, err := subject.ListModels()
@@ -811,7 +811,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 			it("throws an error when the response is empty", func() {
 				subject := factory.buildClientWithoutConfig()
 
-				mockCaller.EXPECT().Get(subject.Config.URL+subject.Config.ModelsPath).Return(nil, nil)
+				mockCaller.EXPECT().Get(gomock.Any(), subject.Config.URL+subject.Config.ModelsPath).Return(nil, nil)
 
 				_, err := subject.ListModels()
 				Expect(err).To(HaveOccurred())
@@ -822,7 +822,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				subject := factory.buildClientWithoutConfig()
 
 				malformed := `{"invalid":"json"` // missing closing brace
-				mockCaller.EXPECT().Get(subject.Config.URL+subject.Config.ModelsPath).
+				mockCaller.EXPECT().Get(gomock.Any(), subject.Config.URL+subject.Config.ModelsPath).
 					Return([]byte(malformed), nil)
 
 				_, err := subject.ListModels()
@@ -836,7 +836,7 @@ func testLLM(t *testing.T, when spec.G, it spec.S) {
 				response, err := test.FileToBytes("models.json")
 				Expect(err).NotTo(HaveOccurred())
 
-				mockCaller.EXPECT().Get(subject.Config.URL+subject.Config.ModelsPath).
+				mockCaller.EXPECT().Get(gomock.Any(), subject.Config.URL+subject.Config.ModelsPath).
 					Return(response, nil)
 
 				result, err := subject.ListModels()

--- a/api/client/mcp.go
+++ b/api/client/mcp.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -271,7 +272,7 @@ func (t *MCPHTTPTransport) Call(endpoint string, req api.MCPMessage, extra map[s
 		merged[k] = v
 	}
 
-	httpResp, postErr := t.caller.PostWithHeadersResponse(endpoint, body, buildMCPHeaders(merged))
+	httpResp, postErr := t.caller.PostWithHeadersResponse(context.Background(), endpoint, body, buildMCPHeaders(merged))
 
 	out := api.MCPResponse{
 		Headers: httpResp.Headers,

--- a/api/client/media.go
+++ b/api/client/media.go
@@ -6,9 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/kardolus/chatgpt-cli/api"
-	"github.com/kardolus/chatgpt-cli/history"
-	"github.com/kardolus/chatgpt-cli/internal"
 	"io"
 	"mime/multipart"
 	stdhttp "net/http"
@@ -16,6 +13,10 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+
+	"github.com/kardolus/chatgpt-cli/api"
+	"github.com/kardolus/chatgpt-cli/history"
+	"github.com/kardolus/chatgpt-cli/internal"
 )
 
 const (
@@ -98,7 +99,7 @@ func (c *Client) EditImage(inputText, inputPath, outputPath string) error {
 		"Content-Type": writer.FormDataContentType(),
 	})
 
-	respBytes, err := c.Caller.PostWithHeaders(endpoint, buf.Bytes(), map[string]string{
+	respBytes, err := c.Caller.PostWithHeaders(context.Background(), endpoint, buf.Bytes(), map[string]string{
 		c.Config.AuthHeader:           fmt.Sprintf("%s %s", c.Config.AuthTokenPrefix, c.Config.APIKey),
 		internal.HeaderContentTypeKey: writer.FormDataContentType(),
 	})
@@ -254,7 +255,7 @@ func (c *Client) Transcribe(audioPath string) (string, error) {
 
 	c.printRequestDebugInfo(endpoint, buf.Bytes(), headers)
 
-	raw, err := c.Caller.PostWithHeaders(endpoint, buf.Bytes(), headers)
+	raw, err := c.Caller.PostWithHeaders(context.Background(), endpoint, buf.Bytes(), headers)
 	if err != nil {
 		return "", err
 	}
@@ -478,7 +479,7 @@ func (c *Client) postAndWriteBinaryOutput(endpoint string, requestBody interface
 
 	c.printRequestDebugInfo(endpoint, body, nil)
 
-	respBytes, err := c.Caller.Post(endpoint, body, false)
+	respBytes, err := c.Caller.Post(context.Background(), endpoint, body, false)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
 	}

--- a/api/client/media_test.go
+++ b/api/client/media_test.go
@@ -54,7 +54,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("throws an error when the http call fails", func() {
-				mockCaller.EXPECT().Post(subject.Config.URL+subject.Config.SpeechPath, body, false).
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, body, false).
 					Return(nil, errors.New(errorText))
 
 				err := subject.SynthesizeSpeech(inputText, fileName)
@@ -63,7 +63,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("throws an error when a file cannot be created", func() {
-				mockCaller.EXPECT().Post(subject.Config.URL+subject.Config.SpeechPath, body, false).
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, body, false).
 					Return(response, nil)
 				mockWriter.EXPECT().Create(fileName).Return(nil, errors.New(errorText))
 
@@ -77,7 +77,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				defer file.Close()
 
-				mockCaller.EXPECT().Post(subject.Config.URL+subject.Config.SpeechPath, body, false).
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, body, false).
 					Return(response, nil)
 				mockWriter.EXPECT().Create(fileName).Return(file, nil)
 				mockWriter.EXPECT().Write(file, response).Return(errors.New(errorText))
@@ -92,7 +92,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				defer file.Close()
 
-				mockCaller.EXPECT().Post(subject.Config.URL+subject.Config.SpeechPath, body, false).
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, body, false).
 					Return(response, nil)
 				mockWriter.EXPECT().Create(fileName).Return(file, nil)
 				mockWriter.EXPECT().Write(file, response).Return(nil)
@@ -127,7 +127,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 
 			it("throws an error when the http call fails", func() {
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
 					Return(nil, errors.New(errorText))
 
 				err := subject.GenerateImage(inputText, outputFile)
@@ -137,7 +137,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 
 			it("throws an error when no image data is returned", func() {
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
 					Return([]byte(`{"data":[]}`), nil)
 
 				err := subject.GenerateImage(inputText, outputFile)
@@ -147,7 +147,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 
 			it("throws an error when base64 is invalid", func() {
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
 					Return([]byte(`{"data":[{"b64_json":"!!notbase64!!"}]}`), nil)
 
 				err := subject.GenerateImage(inputText, outputFile)
@@ -159,7 +159,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				valid := base64.StdEncoding.EncodeToString([]byte("image-bytes"))
 
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
 					Return([]byte(fmt.Sprintf(`{"data":[{"b64_json":"%s"}]}`, valid)), nil)
 
 				mockWriter.EXPECT().Create(outputFile).Return(nil, errors.New(errorText))
@@ -176,7 +176,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				defer file.Close()
 
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
 					Return([]byte(fmt.Sprintf(`{"data":[{"b64_json":"%s"}]}`, valid)), nil)
 
 				mockWriter.EXPECT().Create(outputFile).Return(file, nil)
@@ -194,7 +194,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				defer file.Close()
 
 				mockCaller.EXPECT().
-					Post(subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
+					Post(gomock.Any(), subject.Config.URL+subject.Config.ImageGenerationsPath, body, false).
 					Return([]byte(fmt.Sprintf(`{"data":[{"b64_json":"%s"}]}`, valid)), nil)
 
 				mockWriter.EXPECT().Create(outputFile).Return(file, nil)
@@ -254,7 +254,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 					Return([]byte("\x89PNG\r\n\x1a\n"), nil)
 
 				mockCaller.EXPECT().
-					PostWithHeaders(gomock.Any(), gomock.Any(), gomock.Any()).
+					PostWithHeaders(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New(errorText))
 
 				err := subject.EditImage(inputText, inputFile, outputFile)
@@ -274,7 +274,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 					Return([]byte("\x89PNG\r\n\x1a\n"), nil)
 
 				mockCaller.EXPECT().
-					PostWithHeaders(gomock.Any(), gomock.Any(), gomock.Any()).
+					PostWithHeaders(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(invalidResp, nil)
 
 				err := subject.EditImage(inputText, inputFile, outputFile)
@@ -293,7 +293,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 					Return([]byte("\x89PNG\r\n\x1a\n"), nil)
 
 				mockCaller.EXPECT().
-					PostWithHeaders(gomock.Any(), gomock.Any(), gomock.Any()).
+					PostWithHeaders(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(respBytes, nil)
 
 				mockWriter.EXPECT().Create(outputFile).Return(file, nil)
@@ -334,7 +334,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				mockReader.EXPECT().Open(audioPath).Return(reader, nil)
 
 				mockCaller.EXPECT().
-					PostWithHeaders(subject.Config.URL+subject.Config.TranscriptionsPath, gomock.Any(), gomock.Any())
+					PostWithHeaders(gomock.Any(), subject.Config.URL+subject.Config.TranscriptionsPath, gomock.Any(), gomock.Any())
 
 				_, err = subject.Transcribe(audioPath)
 				Expect(err).To(HaveOccurred())
@@ -354,7 +354,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				mockReader.EXPECT().Open(audioPath).Return(file, nil)
 
 				mockCaller.EXPECT().
-					PostWithHeaders(subject.Config.URL+subject.Config.TranscriptionsPath, gomock.Any(), gomock.Any()).
+					PostWithHeaders(gomock.Any(), subject.Config.URL+subject.Config.TranscriptionsPath, gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("network error"))
 
 				_, err = subject.Transcribe(audioPath)
@@ -378,7 +378,7 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 
 				resp := []byte(`{"text": "Hello, this is a test."}`)
 				mockCaller.EXPECT().
-					PostWithHeaders(subject.Config.URL+subject.Config.TranscriptionsPath, gomock.Any(), gomock.Any()).
+					PostWithHeaders(gomock.Any(), subject.Config.URL+subject.Config.TranscriptionsPath, gomock.Any(), gomock.Any()).
 					Return(resp, nil)
 
 				expectedHistory := []history.History{

--- a/api/client/tools.go
+++ b/api/client/tools.go
@@ -67,7 +67,7 @@ func (c *Client) queryCompletions(ctx context.Context) (string, int, error) {
 		endpoint := c.getChatEndpoint()
 		c.printRequestDebugInfo(endpoint, body, nil)
 
-		raw, err := c.Caller.Post(endpoint, body, false)
+		raw, err := c.Caller.Post(ctx, endpoint, body, false)
 		c.printResponseDebugInfo(raw)
 		if err != nil {
 			return "", total, err

--- a/api/client/tools_test.go
+++ b/api/client/tools_test.go
@@ -28,7 +28,7 @@ type scriptCaller struct {
 	calls     int
 }
 
-func (s *scriptCaller) Post(_ string, body []byte, _ bool) ([]byte, error) {
+func (s *scriptCaller) Post(_ context.Context, _ string, body []byte, _ bool) ([]byte, error) {
 	s.bodies = append(s.bodies, body)
 	i := s.calls
 	s.calls++
@@ -41,11 +41,11 @@ func (s *scriptCaller) Post(_ string, body []byte, _ bool) ([]byte, error) {
 	}
 	return nil, err
 }
-func (s *scriptCaller) PostWithHeaders(_ string, _ []byte, _ map[string]string) ([]byte, error) {
+func (s *scriptCaller) PostWithHeaders(_ context.Context, _ string, _ []byte, _ map[string]string) ([]byte, error) {
 	return nil, nil
 }
-func (s *scriptCaller) Get(_ string) ([]byte, error) { return nil, nil }
-func (s *scriptCaller) PostWithHeadersResponse(_ string, _ []byte, _ map[string]string) (api.HTTPResponse, error) {
+func (s *scriptCaller) Get(_ context.Context, _ string) ([]byte, error) { return nil, nil }
+func (s *scriptCaller) PostWithHeadersResponse(_ context.Context, _ string, _ []byte, _ map[string]string) (api.HTTPResponse, error) {
 	return api.HTTPResponse{}, nil
 }
 

--- a/api/http/http.go
+++ b/api/http/http.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -34,10 +35,10 @@ const (
 )
 
 type Caller interface {
-	Post(url string, body []byte, stream bool) ([]byte, error)
-	PostWithHeaders(url string, body []byte, headers map[string]string) ([]byte, error)
-	Get(url string) ([]byte, error)
-	PostWithHeadersResponse(url string, body []byte, headers map[string]string) (api.HTTPResponse, error)
+	Post(ctx context.Context, url string, body []byte, stream bool) ([]byte, error)
+	PostWithHeaders(ctx context.Context, url string, body []byte, headers map[string]string) ([]byte, error)
+	Get(ctx context.Context, url string) ([]byte, error)
+	PostWithHeadersResponse(ctx context.Context, url string, body []byte, headers map[string]string) (api.HTTPResponse, error)
 }
 
 type RestCaller struct {
@@ -69,16 +70,16 @@ func RealCallerFactory(cfg config.Config) Caller {
 	return New(cfg)
 }
 
-func (r *RestCaller) Get(url string) ([]byte, error) {
-	return r.doRequest(http.MethodGet, url, nil, false)
+func (r *RestCaller) Get(ctx context.Context, url string) ([]byte, error) {
+	return r.doRequest(ctx, http.MethodGet, url, nil, false)
 }
 
-func (r *RestCaller) Post(url string, body []byte, stream bool) ([]byte, error) {
-	return r.doRequest(http.MethodPost, url, body, stream)
+func (r *RestCaller) Post(ctx context.Context, url string, body []byte, stream bool) ([]byte, error) {
+	return r.doRequest(ctx, http.MethodPost, url, body, stream)
 }
 
-func (r *RestCaller) PostWithHeaders(url string, body []byte, headers map[string]string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))
+func (r *RestCaller) PostWithHeaders(ctx context.Context, url string, body []byte, headers map[string]string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf(errFailedToCreateRequest, err)
 	}
@@ -111,13 +112,13 @@ func (r *RestCaller) PostWithHeaders(url string, body []byte, headers map[string
 	return io.ReadAll(resp.Body)
 }
 
-func (r *RestCaller) PostWithHeadersResponse(url string, body []byte, headers map[string]string) (api.HTTPResponse, error) {
+func (r *RestCaller) PostWithHeadersResponse(ctx context.Context, url string, body []byte, headers map[string]string) (api.HTTPResponse, error) {
 	// tests construct RestCaller{} (nil client) — avoid panic
 	if r.client == nil {
 		r.client = http.DefaultClient
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return api.HTTPResponse{}, fmt.Errorf(errFailedToCreateRequest, err)
 	}
@@ -321,7 +322,7 @@ func (r *RestCaller) processResponsesSSE(reader io.Reader, writer io.Writer) ([]
 	return result, nil
 }
 
-func (r *RestCaller) doRequest(method, url string, body []byte, stream bool) ([]byte, error) {
+func (r *RestCaller) doRequest(ctx context.Context, method, url string, body []byte, stream bool) ([]byte, error) {
 	maxRetries := r.config.MaxRetries
 	if maxRetries == 0 {
 		maxRetries = defaultMaxRetries
@@ -332,17 +333,27 @@ func (r *RestCaller) doRequest(method, url string, body []byte, stream bool) ([]
 
 	var response *http.Response
 	for attempt := 0; ; attempt++ {
-		req, err := r.newRequest(method, url, body)
+		// Terminal if the context is already cancelled (e.g. Ctrl-C during a
+		// prior backoff) — bail before spending another attempt.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		req, err := r.newRequest(ctx, method, url, body)
 		if err != nil {
 			return nil, fmt.Errorf(errFailedToCreateRequest, err)
 		}
 
 		resp, err := r.client.Do(req)
 		if err != nil {
+			// A cancelled/expired context is terminal — don't waste retries.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			// Transient network error — retry with backoff (never mid-stream:
 			// we only start reading the body after a successful establishment).
 			if attempt < maxRetries {
-				r.backoff(attempt, "")
+				r.backoff(ctx, attempt, "")
 				continue
 			}
 			return nil, fmt.Errorf(errFailedToMakeRequest, err)
@@ -351,7 +362,7 @@ func (r *RestCaller) doRequest(method, url string, body []byte, stream bool) ([]
 		if shouldRetryStatus(resp.StatusCode) && attempt < maxRetries {
 			retryAfter := resp.Header.Get("Retry-After")
 			_ = resp.Body.Close()
-			r.backoff(attempt, retryAfter)
+			r.backoff(ctx, attempt, retryAfter)
 			continue
 		}
 
@@ -395,31 +406,42 @@ func shouldRetryStatus(code int) bool {
 // backoff waits before the next retry attempt. It honors a Retry-After header
 // (delta-seconds or HTTP-date) when present, otherwise uses exponential backoff
 // with full jitter, capped at maxBackoff.
-func (r *RestCaller) backoff(attempt int, retryAfter string) {
+func (r *RestCaller) backoff(ctx context.Context, attempt int, retryAfter string) {
+	var d time.Duration
+
 	// Honor a positive Retry-After (capped at maxBackoff). A zero/past value is
 	// unusable and falls through to jittered exponential backoff so a broken
 	// "Retry-After: 0" can't turn the retry loop into a hot loop.
-	if d, ok := parseRetryAfter(retryAfter); ok && d > 0 {
+	if ra, ok := parseRetryAfter(retryAfter); ok && ra > 0 {
+		d = ra
 		if d > maxBackoff {
 			d = maxBackoff
 		}
-		time.Sleep(d)
-		return
+	} else {
+		base := r.config.RetryBaseDelayMs
+		if base <= 0 {
+			base = defaultRetryBaseDelayMs
+		}
+		// Cap the shift so a large max_retries can't overflow the duration.
+		shift := attempt
+		if shift > 30 {
+			shift = 30
+		}
+		full := time.Duration(base) * time.Millisecond << uint(shift)
+		if full <= 0 || full > maxBackoff {
+			full = maxBackoff
+		}
+		d = rand.N(full) // full jitter: [0, full)
 	}
-	base := r.config.RetryBaseDelayMs
-	if base <= 0 {
-		base = defaultRetryBaseDelayMs
+
+	// Interruptible sleep — a cancelled context (Ctrl-C) returns immediately
+	// instead of waiting out a multi-second backoff.
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
 	}
-	// Cap the shift so a large max_retries can't overflow the duration.
-	shift := attempt
-	if shift > 30 {
-		shift = 30
-	}
-	d := time.Duration(base) * time.Millisecond << uint(shift)
-	if d <= 0 || d > maxBackoff {
-		d = maxBackoff
-	}
-	time.Sleep(rand.N(d)) // full jitter: [0, d)
 }
 
 func parseRetryAfter(s string) (time.Duration, bool) {
@@ -439,8 +461,8 @@ func parseRetryAfter(s string) (time.Duration, bool) {
 	return 0, false
 }
 
-func (r *RestCaller) newRequest(method, url string, body []byte) (*http.Request, error) {
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+func (r *RestCaller) newRequest(ctx context.Context, method, url string, body []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}

--- a/api/http/http_test.go
+++ b/api/http/http_test.go
@@ -2,6 +2,7 @@ package http_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	stdhttp "net/http"
@@ -108,7 +109,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			defer server.Close()
 
 			subject := chatgpthttp.New(config.Config{MaxRetries: 3, RetryBaseDelayMs: 1})
-			out, err := subject.Post(server.URL, []byte(`{}`), false)
+			out, err := subject.Post(context.Background(), server.URL, []byte(`{}`), false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(out)).To(Equal(`{"ok":true}`))
 			Expect(attempts.Load()).To(Equal(int32(3)))
@@ -129,7 +130,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			defer server.Close()
 
 			subject := chatgpthttp.New(config.Config{MaxRetries: 3, RetryBaseDelayMs: 1})
-			out, err := subject.Post(server.URL, []byte(`{}`), false)
+			out, err := subject.Post(context.Background(), server.URL, []byte(`{}`), false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(out)).To(Equal(`{"ok":true}`))
 			Expect(attempts.Load()).To(Equal(int32(2)))
@@ -147,7 +148,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			defer server.Close()
 
 			subject := chatgpthttp.New(config.Config{MaxRetries: 2, RetryBaseDelayMs: 1})
-			out, err := subject.Post(server.URL, []byte(`{}`), false)
+			out, err := subject.Post(context.Background(), server.URL, []byte(`{}`), false)
 			Expect(err).To(HaveOccurred())
 			Expect(string(out)).To(ContainSubstring("nope"))
 			// 1 initial attempt + 2 retries.
@@ -172,7 +173,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			// Base delay is tiny; only an honored Retry-After can push elapsed past ~1s.
 			subject := chatgpthttp.New(config.Config{MaxRetries: 3, RetryBaseDelayMs: 1})
 			start := time.Now()
-			out, err := subject.Post(server.URL, []byte(`{}`), false)
+			out, err := subject.Post(context.Background(), server.URL, []byte(`{}`), false)
 			elapsed := time.Since(start)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(out)).To(Equal(`{"ok":true}`))
@@ -191,9 +192,41 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			defer server.Close()
 
 			subject := chatgpthttp.New(config.Config{MaxRetries: 3, RetryBaseDelayMs: 1})
-			_, err := subject.Post(server.URL, []byte(`{}`), false)
+			_, err := subject.Post(context.Background(), server.URL, []byte(`{}`), false)
 			Expect(err).To(HaveOccurred())
 			Expect(attempts.Load()).To(Equal(int32(1)))
+		})
+
+		it("aborts immediately when the context is cancelled, without retrying", func() {
+			t.Parallel()
+
+			var attempts atomic.Int32
+			server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+				attempts.Add(1)
+				// Stay slow so the client cancels first; capped so server.Close
+				// can't hang if the cancellation isn't observed server-side.
+				select {
+				case <-r.Context().Done():
+				case <-time.After(2 * time.Second):
+				}
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				cancel()
+			}()
+
+			subject := chatgpthttp.New(config.Config{MaxRetries: 5, RetryBaseDelayMs: 1})
+			start := time.Now()
+			_, err := subject.Post(ctx, server.URL, []byte(`{}`), false)
+			elapsed := time.Since(start)
+
+			Expect(err).To(MatchError(context.Canceled))
+			// A cancelled context is terminal: exactly one attempt, returns fast.
+			Expect(attempts.Load()).To(Equal(int32(1)))
+			Expect(elapsed).To(BeNumerically("<", 2*time.Second))
 		})
 	})
 
@@ -208,7 +241,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			defer server.Close()
 
 			caller := chatgpthttp.New(config.Config{HTTPTimeout: 5})
-			body, err := caller.Get(server.URL)
+			body, err := caller.Get(context.Background(), server.URL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(Equal(`{"ok":true}`))
 		})
@@ -223,7 +256,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 			defer server.Close()
 
 			caller := chatgpthttp.New(config.Config{})
-			body, err := caller.Get(server.URL)
+			body, err := caller.Get(context.Background(), server.URL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(Equal(`{"ok":true}`))
 		})
@@ -242,7 +275,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 
 			subject := chatgpthttp.New(config.Config{})
 
-			body, err := subject.Get(server.URL)
+			body, err := subject.Get(context.Background(), server.URL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(Equal(`{"ok":true}`))
 		})
@@ -266,7 +299,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 
 			subject := chatgpthttp.New(config.Config{})
 
-			out, err := subject.Post(server.URL, []byte(`{"hello":"world"}`), false)
+			out, err := subject.Post(context.Background(), server.URL, []byte(`{"hello":"world"}`), false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(out)).To(Equal(`{"ok":true}`))
 		})
@@ -287,7 +320,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 
 			subject := chatgpthttp.New(config.Config{})
 
-			out, err := subject.PostWithHeaders(server.URL, []byte(`{}`), map[string]string{
+			out, err := subject.PostWithHeaders(context.Background(), server.URL, []byte(`{}`), map[string]string{
 				"X-Test": "abc",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -305,7 +338,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 
 			subject := chatgpthttp.New(config.Config{})
 
-			out, err := subject.PostWithHeaders(server.URL, []byte(`{}`), nil)
+			out, err := subject.PostWithHeaders(context.Background(), server.URL, []byte(`{}`), nil)
 			Expect(err).To(HaveOccurred())
 			Expect(string(out)).To(ContainSubstring(`"nope"`))
 		})
@@ -327,7 +360,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 
 			rc := http.RestCaller{} // ✅ no NewRestCaller
 
-			resp, err := rc.PostWithHeadersResponse(server.URL, []byte(`{"hello":"world"}`), map[string]string{
+			resp, err := rc.PostWithHeadersResponse(context.Background(), server.URL, []byte(`{"hello":"world"}`), map[string]string{
 				"X-Test": "abc",
 			})
 
@@ -354,7 +387,7 @@ func testHTTP(t *testing.T, when spec.G, it spec.S) {
 
 			rc := http.RestCaller{}
 
-			resp, err := rc.PostWithHeadersResponse(server.URL, []byte(`{}`), nil)
+			resp, err := rc.PostWithHeadersResponse(context.Background(), server.URL, []byte(`{}`), nil)
 
 			Expect(err).To(HaveOccurred())
 
@@ -436,7 +469,7 @@ func testCustomHeaders(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			subject := chatgpthttp.New(cfg)
-			_, err := subject.Post(server.URL, []byte(`{"test": "data"}`), false)
+			_, err := subject.Post(context.Background(), server.URL, []byte(`{"test": "data"}`), false)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(receivedHeaders.Get("X-Custom-Header")).To(Equal("custom-value"))
@@ -462,7 +495,7 @@ func testCustomHeaders(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			subject := chatgpthttp.New(cfg)
-			_, err := subject.Get(server.URL)
+			_, err := subject.Get(context.Background(), server.URL)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(receivedHeaders.Get("X-API-Version")).To(Equal("v2"))
@@ -485,7 +518,7 @@ func testCustomHeaders(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			subject := chatgpthttp.New(cfg)
-			_, err := subject.Post(server.URL, []byte(`{"test": "data"}`), false)
+			_, err := subject.Post(context.Background(), server.URL, []byte(`{"test": "data"}`), false)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(receivedHeaders).ToNot(BeNil())
@@ -507,7 +540,7 @@ func testCustomHeaders(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			subject := chatgpthttp.New(cfg)
-			_, err := subject.Post(server.URL, []byte(`{"test": "data"}`), false)
+			_, err := subject.Post(context.Background(), server.URL, []byte(`{"test": "data"}`), false)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(receivedHeaders).ToNot(BeNil())
@@ -535,7 +568,7 @@ func testCustomHeaders(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			subject := chatgpthttp.New(cfg)
-			_, err := subject.Post(server.URL, []byte(`{"test": "data"}`), false)
+			_, err := subject.Post(context.Background(), server.URL, []byte(`{"test": "data"}`), false)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(receivedHeaders.Get("Authorization")).To(Equal("Bearer test-key"))

--- a/cmd/chatgpt/run.go
+++ b/cmd/chatgpt/run.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/chzyer/readline"
@@ -170,6 +172,10 @@ func run(cmd *cobra.Command, args []string) error {
 		cfg.APIKey = key
 	}
 
+	// Base context carries request-scoped values (image/audio/pipe). Ctrl-C
+	// cancellation is layered on per-operation below (withCancelOnSignal) so a
+	// Ctrl-C aborts a single request/turn without poisoning an interactive
+	// session — signal.NotifyContext cancels permanently on the first signal.
 	ctx := context.Background()
 
 	hs, _ := history.New() // do not error out
@@ -376,7 +382,10 @@ func run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		answer, err := runAgent(ctx, c, cfg, mode, goal)
+		agentCtx, stop := withCancelOnSignal(ctx)
+		defer stop()
+
+		answer, err := runAgent(agentCtx, c, cfg, mode, goal)
 		if err != nil {
 			return err
 		}
@@ -457,25 +466,39 @@ func run(cmd *cobra.Command, args []string) error {
 
 			fmtOutputPrompt := utils.FormatPrompt(c.Config.OutputPrompt, qNum, usage, time.Now())
 
+			// Fresh per-turn cancellation: Ctrl-C aborts THIS response and the
+			// loop keeps going (a run-wide signal context would cancel forever
+			// and poison every later prompt).
+			turnCtx, turnStop := withCancelOnSignal(ctx)
+
 			if queryMode {
-				result, qUsage, err := c.Query(ctx, input)
-				if err != nil {
+				result, qUsage, err := c.Query(turnCtx, input)
+				switch {
+				case errors.Is(err, context.Canceled):
+					sugar.Infoln("\n[cancelled]")
+				case err != nil:
 					sugar.Infoln("Error:", err)
-				} else {
+				default:
 					sugar.Infof("%s%s%s\n\n", outputColor, fmtOutputPrompt+result, outPutReset)
 					usage += qUsage
 					qNum++
 				}
 			} else {
 				fmt.Print(outputColor + fmtOutputPrompt)
-				if err := c.Stream(ctx, input); err != nil {
+				err := c.Stream(turnCtx, input)
+				switch {
+				case errors.Is(err, context.Canceled):
+					_, _ = fmt.Fprintln(os.Stderr, "\n[cancelled]")
+				case err != nil:
 					_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
-				} else {
+				default:
 					sugar.Infoln()
 					qNum++
 				}
 				fmt.Print(outPutReset)
 			}
+
+			turnStop()
 		}
 	} else {
 		if len(args) == 0 && !hasPipe {
@@ -493,8 +516,11 @@ func run(cmd *cobra.Command, args []string) error {
 			return c.GenerateImage(chatContext+strings.Join(args, " "), outputFile)
 		}
 
+		oneShotCtx, stop := withCancelOnSignal(ctx)
+		defer stop()
+
 		if queryMode {
-			result, usage, err := c.Query(ctx, strings.Join(args, " "))
+			result, usage, err := c.Query(oneShotCtx, strings.Join(args, " "))
 			if err != nil {
 				return err
 			}
@@ -503,11 +529,19 @@ func run(cmd *cobra.Command, args []string) error {
 			if c.Config.TrackTokenUsage {
 				sugar.Infof("\n[Token Usage: %d]\n", usage)
 			}
-		} else if err := c.Stream(ctx, strings.Join(args, " ")); err != nil {
+		} else if err := c.Stream(oneShotCtx, strings.Join(args, " ")); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// withCancelOnSignal derives a context cancelled on the next Ctrl-C / SIGTERM.
+// The returned stop() must be called when the operation completes to release
+// the signal handler; in the interactive loop each turn gets a fresh one so a
+// Ctrl-C aborts only the current turn rather than the whole session.
+func withCancelOnSignal(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 }
 
 func readInput(rl *readline.Instance, multiline *bool) (string, error) {

--- a/test/contract/contract_test.go
+++ b/test/contract/contract_test.go
@@ -2,7 +2,15 @@ package contract_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/kardolus/chatgpt-cli/api"
 	"github.com/kardolus/chatgpt-cli/api/client"
 	"github.com/kardolus/chatgpt-cli/api/http"
@@ -10,12 +18,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-	"io"
-	"mime/multipart"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 func TestContract(t *testing.T) {
@@ -55,7 +57,7 @@ func testContract(t *testing.T, when spec.G, it spec.S) {
 			bytes, err := json.Marshal(body)
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := restCaller.Post(cfg.URL+cfg.CompletionsPath, bytes, false)
+			resp, err := restCaller.Post(context.Background(), cfg.URL+cfg.CompletionsPath, bytes, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			var data api.CompletionsResponse
@@ -83,7 +85,7 @@ func testContract(t *testing.T, when spec.G, it spec.S) {
 			bytes, err := json.Marshal(body)
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := restCaller.Post(cfg.URL+cfg.CompletionsPath, bytes, false)
+			resp, err := restCaller.Post(context.Background(), cfg.URL+cfg.CompletionsPath, bytes, false)
 			Expect(err).To(HaveOccurred())
 
 			var errorData api.ErrorResponse
@@ -98,7 +100,7 @@ func testContract(t *testing.T, when spec.G, it spec.S) {
 
 	when("accessing the models endpoint", func() {
 		it("should have the expected keys in the response", func() {
-			resp, err := restCaller.Get(cfg.URL + cfg.ModelsPath)
+			resp, err := restCaller.Get(context.Background(), cfg.URL+cfg.ModelsPath)
 			Expect(err).NotTo(HaveOccurred())
 
 			var data api.ListModelsResponse
@@ -135,7 +137,7 @@ func testContract(t *testing.T, when spec.G, it spec.S) {
 			bytes, err := json.Marshal(body)
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := restCaller.Post(cfg.URL+cfg.ResponsesPath, bytes, false)
+			resp, err := restCaller.Post(context.Background(), cfg.URL+cfg.ResponsesPath, bytes, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			var data api.ResponsesResponse
@@ -182,7 +184,7 @@ func testContract(t *testing.T, when spec.G, it spec.S) {
 			bytes, err := json.Marshal(body)
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := restCaller.Post(cfg.URL+cfg.SpeechPath, bytes, false)
+			resp, err := restCaller.Post(context.Background(), cfg.URL+cfg.SpeechPath, bytes, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).NotTo(BeEmpty())
 
@@ -223,7 +225,7 @@ func testContract(t *testing.T, when spec.G, it spec.S) {
 			err = writer.Close()
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := restCaller.PostWithHeaders(cfg.URL+cfg.TranscriptionsPath, buf.Bytes(), map[string]string{
+			resp, err := restCaller.PostWithHeaders(context.Background(), cfg.URL+cfg.TranscriptionsPath, buf.Bytes(), map[string]string{
 				"Content-Type":  writer.FormDataContentType(),
 				"Authorization": "Bearer " + cfg.APIKey,
 			})


### PR DESCRIPTION
## Graceful Ctrl-C (deferred from Track A)

Ctrl-C / SIGTERM now **cancels the in-flight request, stream, or agent loop cleanly** instead of hard-killing the process.

### What changed
- **`http.Caller` takes `ctx`** as its first param; `RestCaller` uses `http.NewRequestWithContext`, and `doRequest` returns `ctx.Err()` immediately (no retry) on cancellation. The retry **backoff sleep is now interruptible** (`select` on `ctx.Done()`), so a Ctrl-C during a multi-second backoff aborts at once.
- **`cmd/chatgpt`** threads a cancellable context into Query/Stream/agent. Instead of a single run-wide `signal.NotifyContext` (which cancels permanently on the first signal), each one-shot command and **each interactive turn** derives its own via `withCancelOnSignal` — in the REPL, Ctrl-C aborts the current response, prints `[cancelled]`, and **keeps the session alive**.
- Regenerated the gomock `MockCaller` + updated all call sites and ~38 mock expectations.

### Cross-model review (GPT-5.5 + Grok + Gemini)
All three caught a real bug I'd otherwise have shipped: a run-wide signal context **poisons the interactive REPL** after the first Ctrl-C (every later prompt would fail instantly with `context.Canceled`). Fixed with **per-turn contexts**. They also flagged the non-interruptible backoff sleep — fixed.

### Scope / follow-up
`ListModels`, the media endpoints, and the MCP transport stay on `context.Background()` for now — all three reviewers agreed this is acceptable incremental scope. Tracked as a follow-up (MCP transport is highest priority since agent tool executions route through it).

### Tests
New http spec: a cancelled context aborts after **exactly one attempt** and returns fast (`< 2s`). `make unit` + `make integration` green; **no new dependencies**.