### PR TITLE
fix(build): compile the cmd package, not just main.go

### DIFF
--- a/scripts/binaries.sh
+++ b/scripts/binaries.sh
@@ -32,9 +32,9 @@ for b in $(ls cmd); do
 
     if [ ! -z "$GIT_TAGS" ]; then
       GIT_VERSION=$(git describe --tags $GIT_TAGS)
-      GOOS=$os GOARCH=$arch go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT -X main.GitVersion=$GIT_VERSION" -o "bin/$binary_name" -a cmd/$b/main.go
+      GOOS=$os GOARCH=$arch go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT -X main.GitVersion=$GIT_VERSION" -o "bin/$binary_name" -a ./cmd/$b
     else
-      GOOS=$os GOARCH=$arch go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT" -o "bin/$binary_name" -a cmd/$b/main.go
+      GOOS=$os GOARCH=$arch go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT" -o "bin/$binary_name" -a ./cmd/$b
     fi
 
     echo "done"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -41,12 +41,12 @@ Get-ChildItem -Directory "cmd" | ForEach-Object {
       $gitVersion = git describe --tags $gitTag
       $env:GOOS = $os
       $env:GOARCH = $arch
-      & go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$gitCommit -X main.GitVersion=$gitVersion" -o "bin/$binaryName" -a "cmd/$b/main.go"
+      & go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$gitCommit -X main.GitVersion=$gitVersion" -o "bin/$binaryName" -a "./cmd/$b"
     }
     else {
       $env:GOOS = $os
       $env:GOARCH = $arch
-      & go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$gitCommit" -o "bin/$binaryName" -a "cmd/$b/main.go"
+      & go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$gitCommit" -o "bin/$binaryName" -a "./cmd/$b"
     }
 
     Write-Host "done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,9 +15,9 @@ for b in $(ls cmd); do
   if [ ! -z "$GIT_TAGS" ]
   then
     GIT_VERSION=$(git describe --tags $GIT_TAGS)
-    GOOS=$TARGET_OS go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT -X main.GitVersion=$GIT_VERSION" -o bin/$b -a cmd/$b/main.go
+    GOOS=$TARGET_OS go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT -X main.GitVersion=$GIT_VERSION" -o bin/$b -a ./cmd/$b
   else
-    GOOS=$TARGET_OS go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT" -o bin/$b -a cmd/$b/main.go
+    GOOS=$TARGET_OS go build -mod=vendor -ldflags="-s -w -X main.GitCommit=$GIT_COMMIT" -o bin/$b -a ./cmd/$b
   fi
 
   echo "done"


### PR DESCRIPTION
## Problem

`make reinstall` (and `make install`) broke after `main.go` was split into sibling files (`run.go`/`flags.go`/`config.go` in #195):

```
cmd/chatgpt/main.go:128:18: undefined: run
cmd/chatgpt/main.go:133:2: undefined: setCustomHelp
cmd/chatgpt/main.go:134:2: undefined: setupFlags
cmd/chatgpt/main.go:142:16: undefined: initConfig
```

The install/release scripts compiled a **single file** (`go build ... -a cmd/$b/main.go`), so once `main.go`'s functions moved into sibling files in the same package, that build no longer sees them.

## Fix

Build the **whole package** (`./cmd/$b`) instead — matching how the Homebrew formula already builds (`./cmd/chatgpt`). Touches `install.sh` (make reinstall/install), `binaries.sh` (**the release path — would also have failed**), and `install.ps1`.

## Why CI missed it

`make unit` / `make integration` use `go test ./...`, which builds packages, so they stayed green. Only the single-file install/release path was affected. Verified `make reinstall` builds + runs (`--version` OK) and a cross-compile target builds via the package form.