### PR TITLE
Add MiniMax text-to-speech support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ calls, and an experimental agent mode for multi-step tasks with safety and budge
     - [Switching Between Configurations with --target](#switching-between-configurations-with---target)
     - [Azure Configuration](#azure-configuration)
     - [Perplexity Configuration](#perplexity-configuration)
+    - [MiniMax Text-to-Speech Configuration](#minimax-text-to-speech-configuration)
     - [302 AI Configuration](#302ai-configuration)
     - [Atlas Cloud Configuration](#atlas-cloud-configuration)
     - [Command-Line Autocompletion](#command-line-autocompletion)
@@ -794,6 +795,26 @@ You can set the API key either in the config.yaml file as shown above or export 
 export PERPLEXITY_API_KEY=<your_key>
 ```
 
+### MiniMax Text-to-Speech Configuration
+
+Create a target configuration for MiniMax text-to-speech requests:
+
+```yaml
+name: minimax
+api_key: <your MiniMax API key>
+model: speech-2.8-hd
+url: https://api.minimax.io
+speech_path: /v1/t2a_v2
+voice: <your MiniMax voice ID>
+```
+
+For the China endpoint, use `https://api.minimaxi.com` as `url`. MiniMax speech output supports `mp3`, `wav`, `flac`,
+and `pcm` file extensions. For example:
+
+```shell
+chatgpt --target minimax --speak "Read this text" --output speech.mp3
+```
+
 You can set the API key either in the `config.yaml` file as shown above or export it as an environment variable:
 
 ```shell
@@ -1027,4 +1048,3 @@ Thank you for using ChatGPT CLI!
         <img src="https://img.shields.io/badge/Back%20to%20Top-000000?style=for-the-badge&logo=github&logoColor=white" alt="Back to Top">
     </a>
 </div>
-

--- a/api/client/media.go
+++ b/api/client/media.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -198,6 +199,30 @@ func (c *Client) GenerateImage(inputText, outputPath string) error {
 //
 // Returns an error if the request fails, the response cannot be written, or the file cannot be created.
 func (c *Client) SynthesizeSpeech(inputText, outputPath string) error {
+	if strings.EqualFold(c.Config.Name, "minimax") {
+		format := strings.ToLower(getExtension(outputPath))
+		if !isMiniMaxSpeechFormat(format) {
+			return fmt.Errorf("unsupported MiniMax speech format: %s", format)
+		}
+
+		req := api.MiniMaxSpeech{
+			Model:        c.Config.Model,
+			Text:         inputText,
+			Stream:       false,
+			OutputFormat: "hex",
+			VoiceSetting: api.MiniMaxVoiceSetting{VoiceID: c.Config.Voice},
+			AudioSetting: api.MiniMaxAudioSetting{Format: format},
+		}
+
+		return c.postAndWriteBinaryOutput(
+			c.getEndpoint(c.Config.SpeechPath),
+			req,
+			outputPath,
+			"binary",
+			decodeMiniMaxSpeechResponse,
+		)
+	}
+
 	req := api.Speech{
 		Model:          c.Config.Model,
 		Voice:          c.Config.Voice,
@@ -205,6 +230,47 @@ func (c *Client) SynthesizeSpeech(inputText, outputPath string) error {
 		ResponseFormat: getExtension(outputPath),
 	}
 	return c.postAndWriteBinaryOutput(c.getEndpoint(c.Config.SpeechPath), req, outputPath, "binary", nil)
+}
+
+func isMiniMaxSpeechFormat(format string) bool {
+	switch format {
+	case "mp3", "wav", "flac", "pcm":
+		return true
+	default:
+		return false
+	}
+}
+
+func decodeMiniMaxSpeechResponse(respBytes []byte) ([]byte, error) {
+	var response struct {
+		Data *struct {
+			Audio  string `json:"audio"`
+			Status int    `json:"status"`
+		} `json:"data"`
+		BaseResponse struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+
+	if err := json.Unmarshal(respBytes, &response); err != nil {
+		return nil, fmt.Errorf("failed to decode MiniMax speech response: %w", err)
+	}
+	if response.BaseResponse.StatusCode != 0 {
+		return nil, fmt.Errorf("MiniMax speech request failed with status %d: %s", response.BaseResponse.StatusCode, response.BaseResponse.StatusMsg)
+	}
+	if response.Data == nil || response.Data.Audio == "" {
+		return nil, fmt.Errorf("MiniMax speech response did not contain audio data")
+	}
+	if response.Data.Status != 2 {
+		return nil, fmt.Errorf("MiniMax speech response was incomplete with status %d", response.Data.Status)
+	}
+
+	audio, err := hex.DecodeString(response.Data.Audio)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode MiniMax speech audio: %w", err)
+	}
+	return audio, nil
 }
 
 // Transcribe uploads an audio file to the OpenAI transcription endpoint and returns the transcribed text.

--- a/api/client/media_test.go
+++ b/api/client/media_test.go
@@ -100,6 +100,62 @@ func testMedia(t *testing.T, when spec.G, it spec.S) {
 				err = subject.SynthesizeSpeech(inputText, fileName)
 				Expect(err).NotTo(HaveOccurred())
 			})
+
+			it("decodes a successful MiniMax speech response", func() {
+				subject.Config.Name = "minimax"
+				subject.Config.Model = "speech-2.8-hd"
+				subject.Config.Voice = "mock-minimax-voice"
+
+				request := api.MiniMaxSpeech{
+					Model:        subject.Config.Model,
+					Text:         inputText,
+					Stream:       false,
+					OutputFormat: "hex",
+					VoiceSetting: api.MiniMaxVoiceSetting{VoiceID: subject.Config.Voice},
+					AudioSetting: api.MiniMaxAudioSetting{Format: outputFileType},
+				}
+				miniMaxBody, err := json.Marshal(request)
+				Expect(err).NotTo(HaveOccurred())
+
+				audio := []byte("mock MiniMax audio")
+				miniMaxResponse := []byte(fmt.Sprintf(
+					`{"data":{"audio":"%x","status":2},"base_resp":{"status_code":0}}`,
+					audio,
+				))
+				file, err := os.Open(os.DevNull)
+				Expect(err).NotTo(HaveOccurred())
+				defer file.Close()
+
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, miniMaxBody, false).
+					Return(miniMaxResponse, nil)
+				mockWriter.EXPECT().Create(fileName).Return(file, nil)
+				mockWriter.EXPECT().Write(file, audio).Return(nil)
+
+				Expect(subject.SynthesizeSpeech(inputText, fileName)).To(Succeed())
+			})
+
+			it("returns a MiniMax status error without creating an output file", func() {
+				subject.Config.Name = "minimax"
+				miniMaxResponse := []byte(`{"base_resp":{"status_code":1001,"status_msg":"request rejected"}}`)
+
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, gomock.Any(), false).
+					Return(miniMaxResponse, nil)
+
+				err := subject.SynthesizeSpeech(inputText, fileName)
+				Expect(err).To(MatchError("MiniMax speech request failed with status 1001: request rejected"))
+			})
+
+			it("returns an error for invalid MiniMax hexadecimal audio", func() {
+				subject.Config.Name = "minimax"
+				miniMaxResponse := []byte(`{"data":{"audio":"not-hex","status":2},"base_resp":{"status_code":0}}`)
+
+				mockCaller.EXPECT().Post(gomock.Any(), subject.Config.URL+subject.Config.SpeechPath, gomock.Any(), false).
+					Return(miniMaxResponse, nil)
+
+				err := subject.SynthesizeSpeech(inputText, fileName)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to decode MiniMax speech audio"))
+			})
 		})
 
 		when("GenerateImage()", func() {

--- a/api/speech.go
+++ b/api/speech.go
@@ -6,3 +6,20 @@ type Speech struct {
 	Voice          string `json:"voice"`
 	ResponseFormat string `json:"response_format"`
 }
+
+type MiniMaxSpeech struct {
+	Model        string              `json:"model"`
+	Text         string              `json:"text"`
+	Stream       bool                `json:"stream"`
+	OutputFormat string              `json:"output_format"`
+	VoiceSetting MiniMaxVoiceSetting `json:"voice_setting"`
+	AudioSetting MiniMaxAudioSetting `json:"audio_setting"`
+}
+
+type MiniMaxVoiceSetting struct {
+	VoiceID string `json:"voice_id"`
+}
+
+type MiniMaxAudioSetting struct {
+	Format string `json:"format"`
+}

--- a/cmd/chatgpt/run.go
+++ b/cmd/chatgpt/run.go
@@ -42,7 +42,7 @@ func run(cmd *cobra.Command, args []string) error {
 		changedFlags[f.Name] = true
 	})
 
-	if err := utils.ValidateFlags(cfg.Model, changedFlags); err != nil {
+	if err := utils.ValidateFlagsForProvider(cfg.Model, cfg.Name, changedFlags); err != nil {
 		return err
 	}
 

--- a/cmd/chatgpt/utils/utils.go
+++ b/cmd/chatgpt/utils/utils.go
@@ -162,6 +162,12 @@ func IsBinary(data []byte) bool {
 }
 
 func ValidateFlags(model string, flags map[string]bool) error {
+	return ValidateFlagsForProvider(model, "", flags)
+}
+
+func ValidateFlagsForProvider(model, provider string, flags map[string]bool) error {
+	ttsCompatible := strings.Contains(model, TTSPattern) || strings.EqualFold(provider, "minimax")
+
 	if flags["new-thread"] && (flags["set-thread"] || flags["thread"]) {
 		return errors.New("the --new-thread flag cannot be used with the --set-thread or --thread flags")
 	}
@@ -189,13 +195,13 @@ func ValidateFlags(model string, flags map[string]bool) error {
 	if flags["transcribe"] && !strings.Contains(model, TranscribePattern) {
 		return errors.New("the --transcribe flag cannot be used without a compatible model, ie gpt-4o-transcribe (see --list-models)")
 	}
-	if flags["speak"] && flags["output"] && !strings.Contains(model, TTSPattern) {
+	if flags["speak"] && flags["output"] && !ttsCompatible {
 		return errors.New("the --speak and --output flags cannot be used without a compatible model, ie gpt-4o-mini-tts (see --list-models)")
 	}
 	if flags["draw"] && flags["output"] && !strings.Contains(model, ImagePattern) {
 		return errors.New("the --draw and --output flags cannot be used without a compatible model, ie gpt-image-1 (see --list-models)")
 	}
-	if flags["voice"] && !strings.Contains(model, TTSPattern) {
+	if flags["voice"] && !ttsCompatible {
 		return errors.New("the --voice flag cannot be used without a compatible model, ie gpt-4o-mini-tts (see --list-models)")
 	}
 	if flags["effort"] && !(strings.Contains(model, O1ProPattern) || strings.Contains(model, GPT5Pattern)) {

--- a/cmd/chatgpt/utils/utils_test.go
+++ b/cmd/chatgpt/utils/utils_test.go
@@ -286,6 +286,13 @@ func testUtils(t *testing.T, when spec.G, it spec.S) {
 			err := utils.ValidateFlags(defaultModel+utils.TTSPattern, flags)
 			Expect(err).NotTo(HaveOccurred())
 		})
+		it("should NOT return an error when --speak and --output flags use the MiniMax provider", func() {
+			flags["speak"] = true
+			flags["output"] = true
+
+			err := utils.ValidateFlagsForProvider(defaultModel, "minimax", flags)
+			Expect(err).NotTo(HaveOccurred())
+		})
 		it("should return an error when --draw and --output flags are used with an incompatible model", func() {
 			flags["draw"] = true
 			flags["output"] = true
@@ -318,6 +325,12 @@ func testUtils(t *testing.T, when spec.G, it spec.S) {
 			flags["voice"] = true
 
 			err := utils.ValidateFlags(defaultModel+utils.TTSPattern, flags)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		it("should NOT return an error when --voice uses the MiniMax provider", func() {
+			flags["voice"] = true
+
+			err := utils.ValidateFlagsForProvider(defaultModel, "minimax", flags)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		it("should return an error when --effort is used with an incompatible model", func() {


### PR DESCRIPTION
Reason: Enable MiniMax text-to-speech through the CLI's existing speech command.

This change:

- sends MiniMax speech requests with `text`, `voice_setting`, `audio_setting`, and non-streaming hexadecimal output;
- validates the provider response and decodes `data.audio` before writing the requested audio file;
- allows MiniMax configurations through the speech and voice flag checks; and
- documents both global and China endpoint configuration.

Checks:

- `go test -mod=vendor ./api/client ./cmd/chatgpt/utils`
- `make unit`
- `make integration`
- `CONFIG_PATH="file://$PWD" TESTING=true go test -parallel 1 -timeout 0 -mod=vendor ./test/integration -v -run Integration`
- `go mod tidy -diff && golangci-lint run`
